### PR TITLE
feat(map): improve tile preloading to reduce greyed-out areas

### DIFF
--- a/frontend/src/hooks/useLeafletMap.ts
+++ b/frontend/src/hooks/useLeafletMap.ts
@@ -50,10 +50,20 @@ export const useLeafletMap = ({
       boxZoom: false,
     })
 
-    // Add tile layer
+    // Add tile layer with optimized preloading
     L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png', {
       attribution: '© OpenStreetMap contributors, © CARTO',
       maxZoom: 19,
+      minZoom: 10, // Prevent excessive zoom out for Toronto area
+      keepBuffer: 4, // Keep 4 tiles outside viewport (default: 2) - balances UX and performance
+      updateWhenIdle: false, // Update tiles while dragging for smoother experience
+      updateWhenZooming: false, // Don't update during zoom transitions
+      updateInterval: 150, // Throttle tile updates during movement (default: 200ms)
+      // Bounds restriction to Toronto area to prevent unnecessary tile loading
+      bounds: [
+        [43.5, -79.7], // Southwest corner (slightly south and west of Toronto)
+        [43.9, -79.0]  // Northeast corner (slightly north and east of Toronto)
+      ]
     }).addTo(map)
 
     mapRef.current = map


### PR DESCRIPTION
Improves map tile preloading to reduce greyed-out areas when dragging while maintaining performance budget.

## Changes
- Increase keepBuffer from 2 to 4 tiles for better preloading
- Add minZoom: 10 to prevent excessive zoom out
- Set updateWhenIdle: false for smoother dragging experience
- Set updateWhenZooming: false to prevent jarring transitions
- Reduce updateInterval to 150ms for faster tile response
- Add bounds restriction to Toronto area to prevent unnecessary requests

Fixes #24

Generated with [Claude Code](https://claude.ai/code)