### PR TITLE
Fix map tiles not loading when switching cities

### DIFF
--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -119,7 +119,8 @@ export const MapView: React.FC<MapViewProps> = ({ cafes, showPopover, selectedCa
     removeUserLocationMarker,
     centerOnLocation,
     drawRoute,
-    clearRoute: clearRouteVisual
+    clearRoute: clearRouteVisual,
+    refreshTiles
   } = useLeafletMap({
     cafes: filteredCafes,
     onPinClick,
@@ -219,6 +220,16 @@ export const MapView: React.FC<MapViewProps> = ({ cafes, showPopover, selectedCa
       clearRouteData()
     }
   }, [selectedCafe?.id, clearRouteVisual, clearRouteData])
+
+  // Force tile refresh when city changes to ensure tiles load properly
+  React.useEffect(() => {
+    // Small delay to allow city change to propagate and map to center
+    const timeoutId = setTimeout(() => {
+      refreshTiles()
+    }, 300)
+    
+    return () => clearTimeout(timeoutId)
+  }, [selectedCity, refreshTiles])
 
   return (
     <div className="flex-1 relative">
@@ -639,10 +650,12 @@ export const MapView: React.FC<MapViewProps> = ({ cafes, showPopover, selectedCa
                   isProgrammaticChangeRef.current = true
                   setCity(cityKey)
                   setShowCityDropdown(false)
-                  // Pan map to new city center
+                  // Pan map to new city center with enhanced tile loading
                   if (centerOnLocation) {
                     const newCity = CITIES[cityKey]
                     centerOnLocation(newCity.center[0], newCity.center[1], newCity.zoom)
+                    // Additional tile refresh for better reliability
+                    setTimeout(() => refreshTiles(), 200)
                   }
                 }}
                 className={`w-full text-left px-3 py-2 text-sm hover:bg-matcha-50 transition-colors ${

--- a/frontend/src/hooks/useLeafletMap.ts
+++ b/frontend/src/hooks/useLeafletMap.ts
@@ -31,6 +31,7 @@ export const useLeafletMap = ({
   onMapMove
 }: UseLeafletMapOptions) => {
   const mapRef = useRef<L.Map | null>(null)
+  const tileLayerRef = useRef<L.TileLayer | null>(null)
   const markersRef = useRef<Map<number, L.Marker>>(new Map())
   const userLocationMarkerRef = useRef<L.Marker | null>(null)
   const routeLayerRef = useRef<L.Polyline | null>(null)
@@ -50,21 +51,19 @@ export const useLeafletMap = ({
       boxZoom: false,
     })
 
-    // Add tile layer with optimized preloading
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png', {
+    // Add tile layer with improved preloading for city switching
+    const tileLayer = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png', {
       attribution: '© OpenStreetMap contributors, © CARTO',
       maxZoom: 19,
-      minZoom: 10, // Prevent excessive zoom out for Toronto area
-      keepBuffer: 4, // Keep 4 tiles outside viewport (default: 2) - balances UX and performance
-      updateWhenIdle: false, // Update tiles while dragging for smoother experience
-      updateWhenZooming: false, // Don't update during zoom transitions
-      updateInterval: 150, // Throttle tile updates during movement (default: 200ms)
-      // Bounds restriction to Toronto area to prevent unnecessary tile loading
-      bounds: [
-        [43.5, -79.7], // Southwest corner (slightly south and west of Toronto)
-        [43.9, -79.0]  // Northeast corner (slightly north and east of Toronto)
-      ]
+      minZoom: 8, // Allow more zoom out for global cities
+      keepBuffer: 6, // Increased from 4 to prevent grey areas during city switching
+      updateWhenIdle: false, // Load tiles during pan for smoother experience
+      updateWhenZooming: false, // Don't update during zoom animations
+      updateInterval: 100, // Faster updates (reduced from 150ms)
+      // Remove bounds restriction to allow global tile loading for all cities
     }).addTo(map)
+    
+    tileLayerRef.current = tileLayer
 
     mapRef.current = map
 
@@ -136,7 +135,22 @@ export const useLeafletMap = ({
   }
 
   const centerOnLocation = useCallback((lat: number, lng: number, zoom?: number) => {
-    mapRef.current?.setView([lat, lng], zoom ?? 15)
+    if (!mapRef.current) return
+    
+    // Pan to new location
+    mapRef.current.setView([lat, lng], zoom ?? 15)
+    
+    // Force tile layer refresh to ensure tiles load for new viewport
+    if (tileLayerRef.current) {
+      // Small delay to allow pan animation to complete
+      setTimeout(() => {
+        if (tileLayerRef.current && mapRef.current) {
+          tileLayerRef.current.redraw()
+          // Also invalidate map size to trigger tile recalculation
+          mapRef.current.invalidateSize()
+        }
+      }, 100)
+    }
   }, [])
 
   const addUserLocationMarker = (lat: number, lng: number) => {
@@ -218,6 +232,13 @@ export const useLeafletMap = ({
     }
   }, [])
 
+  const refreshTiles = useCallback(() => {
+    if (tileLayerRef.current && mapRef.current) {
+      tileLayerRef.current.redraw()
+      mapRef.current.invalidateSize()
+    }
+  }, [])
+
   return {
     containerRef,
     zoomIn,
@@ -227,6 +248,7 @@ export const useLeafletMap = ({
     removeUserLocationMarker,
     drawRoute,
     clearRoute,
+    refreshTiles,
     map: mapRef.current,
   }
 }


### PR DESCRIPTION
Fixes #53 - Map tiles not loading when switching cities

## Summary
Fixed the issue where map tiles wouldn't load after selecting a different city from the dropdown. The map viewport would pan correctly but tiles remained grey/blank.

## Root Cause
- Restrictive Toronto-only tile bounds prevented global tile loading
- Insufficient tile preloading during city switches
- Missing tile layer refresh after viewport changes

## Changes Made

### Enhanced Tile Layer Configuration (`useLeafletMap.ts`):
- Removed restrictive Toronto-only bounds to allow global cities
- Increased `keepBuffer` from 4 to 6 tiles for better preloading
- Reduced `updateInterval` from 150ms to 100ms for faster updates
- Expanded `minZoom` from 10 to 8 to support global cities

### Added Tile Refresh System:
- Added `tileLayerRef` to track tile layer instance
- Created `refreshTiles()` function for forced tile redraw
- Enhanced `centerOnLocation()` to auto-refresh after panning

### Improved City Switching (`MapView.tsx`):
- Added extra tile refresh when cities switched in dropdown
- Added effect to refresh tiles when selected city changes
- Used appropriate delays for animation completion

## Testing
- ✅ Selecting a city triggers map tile loading for new viewport
- ✅ Map tiles render smoothly during/after pan animation
- ✅ Increased tile preloading radius prevents grey areas
- ✅ Ready for production build testing
- ✅ Works on both mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.ai/code)