### PR TITLE
fix: enable user accounts in production to fix login route redirect

### DIFF
--- a/frontend/src/config/features.yaml
+++ b/frontend/src/config/features.yaml
@@ -65,7 +65,7 @@ ENABLE_CITY_SELECTOR:
 # User authentication and account features like favoriting cafes
 ENABLE_USER_ACCOUNTS:
   dev: true
-  prod: false
+  prod: true
 
 # User Profiles
 # Public user profile pages showing activity and stats


### PR DESCRIPTION
Fixes the login route redirect issue (##59) by enabling user accounts in production.

## Changes
- Change `ENABLE_USER_ACCOUNTS.prod` from `false` to `true` in `frontend/src/config/features.yaml`
- Fixes issue where `/login` route redirects to home page on production
- Now allows users to access login/registration forms in production
- Enables admin authentication to access admin panel

## Testing
After deployment:
1. Navigate to `/login` on production
2. Verify LoginPage component renders with login and registration forms
3. Test authentication flow end-to-end
4. Verify admin users can access `/admin` routes

Generated with [Claude Code](https://claude.ai/code)