### PR TITLE
fix: correct timestamp format for waitlist signup stats queries

### DIFF
--- a/backend/src/routes/waitlist.ts
+++ b/backend/src/routes/waitlist.ts
@@ -108,12 +108,17 @@ export async function getWaitlistAdmin(request: IRequest, env: Env): Promise<Res
     // Calculate analytics
     const now = new Date();
     
+    // Helper function to format dates for SQLite (YYYY-MM-DD HH:MM:SS)
+    const toSQLiteDateTime = (date: Date): string => {
+      return date.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
+    };
+    
     // Daily signups: last 24 hours
     const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
     const dailySignupsResult = await db
       .select({ count: count() })
       .from(waitlist)
-      .where(gte(waitlist.createdAt, oneDayAgo.toISOString()))
+      .where(gte(waitlist.createdAt, toSQLiteDateTime(oneDayAgo)))
       .get();
 
     // Weekly signups: last 7 days
@@ -121,7 +126,7 @@ export async function getWaitlistAdmin(request: IRequest, env: Env): Promise<Res
     const weeklySignupsResult = await db
       .select({ count: count() })
       .from(waitlist)
-      .where(gte(waitlist.createdAt, sevenDaysAgo.toISOString()))
+      .where(gte(waitlist.createdAt, toSQLiteDateTime(sevenDaysAgo)))
       .get();
 
     const analytics = {


### PR DESCRIPTION
SQLite CURRENT_TIMESTAMP uses 'YYYY-MM-DD HH:MM:SS' format but JavaScript toISOString() uses 'YYYY-MM-DDTHH:MM:SS.sssZ' format. This mismatch caused the gte() comparisons to fail, resulting in daily/weekly stats always showing 0.

Added toSQLiteDateTime() helper to convert JS dates to SQLite format.

Fixes #62

Generated with [Claude Code](https://claude.ai/code)