### PR TITLE
fix: Convert UTC timestamps to local timezone in admin panels

### DIFF
--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { X, Mail, Calendar, Shield, CheckCircle, XCircle, MapPin, Instagram, Globe, Clock, Star } from 'lucide-react'
 import { api } from '../../utils/api'
 import type { User, UserProfile } from '../../../../shared/types'
+import { formatDate, formatRelativeTime } from '../../utils/dateFormatter'
 
 interface UserDetailModalProps {
   userId: number
@@ -38,29 +39,6 @@ export const UserDetailModal: React.FC<UserDetailModalProps> = ({ userId, onClos
     }
   }
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  }
-
-  const formatLastActive = (dateString: string | null | undefined) => {
-    if (!dateString) return 'Never'
-    const date = new Date(dateString)
-    const now = new Date()
-    const diffMs = now.getTime() - date.getTime()
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
-
-    if (diffDays === 0) return 'Today'
-    if (diffDays === 1) return 'Yesterday'
-    if (diffDays < 7) return `${diffDays} days ago`
-    if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`
-    return formatDate(dateString)
-  }
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[10000] p-4">
@@ -145,7 +123,7 @@ export const UserDetailModal: React.FC<UserDetailModalProps> = ({ userId, onClos
                     <div>
                       <p className="text-xs text-gray-500">Joined</p>
                       <p className="text-sm font-medium text-gray-900">
-                        {formatDate(userDetails.user.createdAt)}
+                        {formatDate(userDetails.user.createdAt, { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                       </p>
                     </div>
                   </div>
@@ -154,7 +132,7 @@ export const UserDetailModal: React.FC<UserDetailModalProps> = ({ userId, onClos
                     <div>
                       <p className="text-xs text-gray-500">Last Active</p>
                       <p className="text-sm font-medium text-gray-900">
-                        {formatLastActive(userDetails.user.lastActiveAt)}
+                        {formatRelativeTime(userDetails.user.lastActiveAt)}
                       </p>
                     </div>
                   </div>

--- a/frontend/src/components/admin/UserManagementPage.tsx
+++ b/frontend/src/components/admin/UserManagementPage.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '../../stores/authStore'
 import { UserDetailModal } from './UserDetailModal'
 import { AlertDialog } from '../../components/ui'
 import { COPY } from '../../constants/copy'
+import { formatDate, formatRelativeTime } from '../../utils/dateFormatter'
 
 export const UserManagementPage: React.FC = () => {
   const { user: currentUser } = useAuthStore()
@@ -103,27 +104,6 @@ export const UserManagementPage: React.FC = () => {
     setViewingUserId(userId)
   }
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    })
-  }
-
-  const formatLastActive = (dateString: string | null) => {
-    if (!dateString) return COPY.admin.userManagement.never
-    const date = new Date(dateString)
-    const now = new Date()
-    const diffMs = now.getTime() - date.getTime()
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
-
-    if (diffDays === 0) return COPY.admin.userManagement.today
-    if (diffDays === 1) return COPY.admin.userManagement.yesterday
-    if (diffDays < 7) return COPY.admin.userManagement.daysAgo(diffDays)
-    if (diffDays < 30) return COPY.admin.userManagement.weeksAgo(Math.floor(diffDays / 7))
-    return formatDate(dateString)
-  }
 
   return (
     <div className="p-4 md:p-6">
@@ -314,10 +294,10 @@ export const UserManagementPage: React.FC = () => {
                           {user.totalCheckins} check-ins • {user.totalReviews} reviews
                         </span>
                         <span className="text-xs">
-                          Joined: {formatDate(user.createdAt)}
+                          Joined: {formatDate(user.createdAt, { year: 'numeric', month: 'short', day: 'numeric' })}
                         </span>
                         <span className="text-xs">
-                          Last active: {formatLastActive(user.lastActiveAt)}
+                          Last active: {formatRelativeTime(user.lastActiveAt)}
                         </span>
                       </div>
                     </div>

--- a/frontend/src/components/admin/WaitlistPage.tsx
+++ b/frontend/src/components/admin/WaitlistPage.tsx
@@ -4,6 +4,7 @@ import { api } from '../../utils/api'
 import { COPY } from '../../constants/copy'
 import { PrimaryButton, SecondaryButton, StatusBadge } from '../ui'
 import { Skeleton } from '../ui'
+import { formatDate, formatDateForCSV } from '../../utils/dateFormatter'
 
 interface WaitlistEntry {
   id: number
@@ -101,10 +102,10 @@ export const WaitlistPage: React.FC = () => {
       headers.join(','),
       ...data.waitlist.map(entry => [
         entry.email,
-        new Date(entry.createdAt).toLocaleDateString(),
+        formatDateForCSV(entry.createdAt),
         entry.referralSource || '',
         entry.converted ? 'Converted' : 'Pending',
-        entry.convertedAt ? new Date(entry.convertedAt).toLocaleDateString() : ''
+        entry.convertedAt ? formatDateForCSV(entry.convertedAt) : ''
       ].map(field => `"${field}"`).join(','))
     ].join('\n')
 
@@ -119,16 +120,6 @@ export const WaitlistPage: React.FC = () => {
     window.URL.revokeObjectURL(url)
   }
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return date.toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    })
-  }
 
   if (loading) {
     return (

--- a/frontend/src/constants/copy.ts
+++ b/frontend/src/constants/copy.ts
@@ -403,6 +403,13 @@ export const COPY = {
       daysAgo: (days: number) => `${days} days ago`,
       weeksAgo: (weeks: number) => `${weeks} weeks ago`,
     },
+
+    // Date formatting
+    dateTime: {
+      justNow: 'Just now',
+      minutesAgo: (minutes: number) => `${minutes} minute${minutes === 1 ? '' : 's'} ago`,
+      hoursAgo: (hours: number) => `${hours} hour${hours === 1 ? '' : 's'} ago`,
+    },
   },
 } as const
 

--- a/frontend/src/utils/dateFormatter.ts
+++ b/frontend/src/utils/dateFormatter.ts
@@ -1,0 +1,84 @@
+/**
+ * Date formatting utilities for MatchaMap admin panels
+ * 
+ * Handles proper UTC timestamp conversion for database timestamps
+ * that are stored in SQLite CURRENT_TIMESTAMP format (YYYY-MM-DD HH:MM:SS)
+ */
+
+import { COPY } from '../constants/copy'
+
+/**
+ * Formats a UTC timestamp from the database to local time
+ * Handles SQLite's CURRENT_TIMESTAMP format (YYYY-MM-DD HH:MM:SS)
+ * 
+ * @param dateString - UTC timestamp from database
+ * @param options - Intl.DateTimeFormatOptions for custom formatting
+ * @returns Formatted date string in user's local timezone
+ */
+export function formatDate(dateString: string, options?: Intl.DateTimeFormatOptions): string {
+  // Ensure the date string is treated as UTC
+  // SQLite returns: "2025-10-09 19:00:00" (no 'T', no 'Z')
+  // Convert to ISO 8601 UTC format: "2025-10-09T19:00:00Z"
+  const isoDate = dateString.replace(' ', 'T') + (dateString.endsWith('Z') ? '' : 'Z')
+  const date = new Date(isoDate)
+  
+  const defaultOptions: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    ...options
+  }
+  
+  return date.toLocaleString('en-US', defaultOptions)
+}
+
+/**
+ * Formats a date as a relative time (e.g., "2 hours ago", "Yesterday")
+ * Falls back to formatDate() for older dates
+ * 
+ * @param dateString - UTC timestamp from database (can be null/undefined)
+ * @returns Human-readable relative time string
+ */
+export function formatRelativeTime(dateString: string | null | undefined): string {
+  if (!dateString) return COPY.admin.userManagement.never
+  
+  const isoDate = dateString.replace(' ', 'T') + (dateString.endsWith('Z') ? '' : 'Z')
+  const date = new Date(isoDate)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
+  const diffMinutes = Math.floor(diffMs / (1000 * 60))
+  
+  if (diffMinutes < 1) return COPY.admin.dateTime.justNow
+  if (diffMinutes < 60) return COPY.admin.dateTime.minutesAgo(diffMinutes)
+  if (diffHours < 24) return COPY.admin.dateTime.hoursAgo(diffHours)
+  if (diffDays === 0) return COPY.admin.userManagement.today
+  if (diffDays === 1) return COPY.admin.userManagement.yesterday
+  if (diffDays < 7) return COPY.admin.userManagement.daysAgo(diffDays)
+  if (diffDays < 30) return COPY.admin.userManagement.weeksAgo(Math.floor(diffDays / 7))
+  
+  return formatDate(dateString, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+/**
+ * Formats a date for CSV export with timezone information
+ * 
+ * @param dateString - UTC timestamp from database
+ * @returns Formatted date string with timezone for CSV export
+ */
+export function formatDateForCSV(dateString: string): string {
+  const isoDate = dateString.replace(' ', 'T') + (dateString.endsWith('Z') ? '' : 'Z')
+  const date = new Date(isoDate)
+  
+  return date.toLocaleString('en-US', { 
+    year: 'numeric',
+    month: 'short', 
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZoneName: 'short'
+  })
+}


### PR DESCRIPTION
Fixes UTC timestamp display issue in admin panels where database timestamps were showing incorrect times due to timezone parsing problems.

## Changes
- Create shared dateFormatter.ts utility with proper UTC handling
- Fix SQLite timestamp parsing by converting to ISO 8601 UTC format
- Update WaitlistPage, UserManagementPage, and UserDetailModal components
- Add timezone information to CSV exports
- Remove duplicate date formatting functions
- Add COPY constants for consistent date strings

## Testing
- All admin panel timestamps now display in user's local timezone
- Relative times ("Today", "Yesterday", "X hours ago") are accurate
- CSV exports include timezone information

Fixes #61

Generated with [Claude Code](https://claude.ai/code)