### PR TITLE
feat(auth): Add token expiration detection and recovery handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import Header from './components/Header'
 import BottomNavigation from './components/BottomNavigation'
 import AppRoutes from './components/AppRoutes'
 import ComingSoon from './components/ComingSoon'
+import { SessionExpiredDialog } from './components/SessionExpiredDialog'
 import { useAppFeatures } from './hooks/useAppFeatures'
 
 const SESSION_KEY = 'matchamap_unlocked'
@@ -28,6 +29,7 @@ export const App: React.FC = () => {
       <Header />
       <AppRoutes />
       <BottomNavigation />
+      <SessionExpiredDialog />
     </div>
   )
 }

--- a/frontend/src/components/SessionExpiredDialog.tsx
+++ b/frontend/src/components/SessionExpiredDialog.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AlertDialog } from './ui/AlertDialog'
+import { COPY } from '../constants/copy'
+import { useSessionExpiry } from '../hooks/useSessionExpiry'
+
+/**
+ * SessionExpiredDialog - Shows when authentication token expires
+ * Provides option to navigate to login page with redirect preservation
+ */
+export const SessionExpiredDialog: React.FC = () => {
+  const navigate = useNavigate()
+  const { showDialog, hideSessionExpiredDialog, getIntendedDestination, clearIntendedDestination } = useSessionExpiry()
+
+  const handleSignInAgain = () => {
+    const redirectPath = getIntendedDestination()
+    hideSessionExpiredDialog()
+    
+    // Navigate to login with redirect parameter
+    const loginPath = redirectPath 
+      ? `/login?redirect=${encodeURIComponent(redirectPath)}`
+      : '/login'
+    
+    navigate(loginPath)
+  }
+
+  const handleDismiss = () => {
+    hideSessionExpiredDialog()
+    clearIntendedDestination()
+  }
+
+  if (!showDialog) {
+    return null
+  }
+
+  return (
+    <AlertDialog
+      variant="warning"
+      title={COPY.auth.sessionExpired.title}
+      message={COPY.auth.sessionExpired.message}
+      primaryAction={{
+        label: COPY.auth.sessionExpired.signInAgain,
+        onClick: handleSignInAgain,
+      }}
+      secondaryAction={{
+        label: COPY.auth.sessionExpired.dismiss,
+        onClick: handleDismiss,
+      }}
+    />
+  )
+}

--- a/frontend/src/components/auth/LoginPage.tsx
+++ b/frontend/src/components/auth/LoginPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router'
 import { useAuthStore } from '../../stores/authStore'
+import { useSessionExpiry } from '../../hooks/useSessionExpiry'
 import { LoginForm } from './LoginForm'
 import { RegisterForm } from './RegisterForm'
 import { COPY } from '../../constants/copy'
@@ -9,21 +10,30 @@ export const LoginPage: React.FC = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const { isAuthenticated, user } = useAuthStore()
+  const { clearIntendedDestination } = useSessionExpiry()
   const [mode, setMode] = useState<'login' | 'register'>('login')
 
-  // Get the redirect path from location state
-  const from = (location.state as { from?: string })?.from
+  // Get the redirect path from location state or query parameter
+  const searchParams = new URLSearchParams(location.search)
+  const redirectParam = searchParams.get('redirect')
+  const from = redirectParam || (location.state as { from?: string })?.from
 
   useEffect(() => {
     // If already authenticated, redirect appropriately
     if (isAuthenticated && user) {
+      // Clear any stored intended destination
+      clearIntendedDestination()
+      
       // Admins go to admin panel, regular users go to their profile
       const destination = from || (user.role === 'admin' ? '/admin' : `/profile/${user.username}`)
       navigate(destination, { replace: true })
     }
-  }, [isAuthenticated, user, navigate, from])
+  }, [isAuthenticated, user, navigate, from, clearIntendedDestination])
 
   const handleSuccess = () => {
+    // Clear any stored intended destination
+    clearIntendedDestination()
+    
     // After successful login/register, redirect based on role
     if (user) {
       const destination = from || (user.role === 'admin' ? '/admin' : `/profile/${user.username}`)

--- a/frontend/src/constants/copy.ts
+++ b/frontend/src/constants/copy.ts
@@ -267,6 +267,14 @@ export const COPY = {
     passwordsDoNotMatch: 'Passwords do not match',
     usernameTooShort: 'Username must be at least 3 characters long',
     usernameInvalidChars: 'Username can only contain letters, numbers, and underscores',
+
+    // Session Expiration
+    sessionExpired: {
+      title: 'Session Expired',
+      message: 'Your session has expired. Please sign in again to continue.',
+      signInAgain: 'Sign In Again',
+      dismiss: 'Dismiss',
+    },
   },
 
   // Profile

--- a/frontend/src/hooks/useSessionExpiry.ts
+++ b/frontend/src/hooks/useSessionExpiry.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand'
+
+interface SessionExpiryState {
+  showDialog: boolean
+  intendedDestination: string | null
+  
+  // Actions
+  showSessionExpiredDialog: (currentPath?: string) => void
+  hideSessionExpiredDialog: () => void
+  getIntendedDestination: () => string | null
+  clearIntendedDestination: () => void
+}
+
+/**
+ * Hook for managing session expiry dialog state
+ * Stores the intended destination for post-login redirect
+ */
+export const useSessionExpiry = create<SessionExpiryState>((set, get) => ({
+  showDialog: false,
+  intendedDestination: null,
+
+  showSessionExpiredDialog: (currentPath?: string) => {
+    // Store current path in sessionStorage for post-login redirect
+    if (currentPath) {
+      sessionStorage.setItem('matchamap-redirect-after-login', currentPath)
+      set({ intendedDestination: currentPath })
+    }
+    set({ showDialog: true })
+  },
+
+  hideSessionExpiredDialog: () => {
+    set({ showDialog: false })
+  },
+
+  getIntendedDestination: () => {
+    const stored = sessionStorage.getItem('matchamap-redirect-after-login')
+    return stored || get().intendedDestination
+  },
+
+  clearIntendedDestination: () => {
+    sessionStorage.removeItem('matchamap-redirect-after-login')
+    set({ intendedDestination: null })
+  },
+}))

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -16,6 +16,7 @@ interface AuthState {
   login: (credentials: LoginRequest) => Promise<void>
   register: (data: RegisterRequest) => Promise<void>
   logout: () => void
+  clearAuth: () => void
   refreshAccessToken: () => Promise<boolean>
   getCurrentUser: () => Promise<void>
   clearError: () => void
@@ -111,6 +112,22 @@ export const useAuthStore = create<AuthState>()(
         }
 
         // Clear auth state
+        set({
+          user: null,
+          accessToken: null,
+          refreshToken: null,
+          isAuthenticated: false,
+          error: null,
+          isLoading: false,
+        })
+
+        // Explicitly clear sessionStorage to ensure tokens are removed
+        sessionStorage.removeItem('matchamap-auth')
+      },
+
+      clearAuth: () => {
+        // Clear auth state without calling logout endpoint
+        // Used when token is already invalid (401/403 responses)
         set({
           user: null,
           accessToken: null,

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -4,6 +4,7 @@
  */
 
 import { useAuthStore } from '../stores/authStore'
+import { useSessionExpiry } from '../hooks/useSessionExpiry'
 import type { Cafe, Drink, FeedItem, Event, PublicUserProfile, UpdateProfileRequest, UserProfile, CityWithCount, User } from '../../../shared/types'
 
 const API_BASE_URL = import.meta.env.VITE_API_URL;
@@ -41,6 +42,19 @@ async function fetchAPI<T>(endpoint: string, options?: RequestInit & { bustCache
     })
 
     if (!response.ok) {
+      // Handle authentication errors (401/403)
+      if (response.status === 401 || response.status === 403) {
+        // Clear expired tokens from auth store
+        useAuthStore.getState().clearAuth()
+        
+        // Show session expired dialog with current path for redirect
+        const currentPath = window.location.pathname + window.location.search
+        useSessionExpiry.getState().showSessionExpiredDialog(currentPath)
+        
+        // Return a specific error for auth failures
+        throw new Error('Authentication required')
+      }
+
       const errorData = await response.json().catch(() => ({ error: 'Unknown error' }))
       throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`)
     }


### PR DESCRIPTION
Add comprehensive auth token expiration handling across the application

## Changes
- Add session expired copy constants to copy.ts
- Add clearAuth() method to authStore for token cleanup
- Create useSessionExpiry hook for dialog state management
- Add SessionExpiredDialog component with warning UI
- Update API client to detect 401/403 and show expiry dialog
- Integrate dialog globally in App.tsx
- Update LoginPage to handle redirect query parameter
- Preserve intended destination for post-login redirect

Closes #84

🤖 Generated with [Claude Code](https://claude.ai/code)