### PR TITLE
fix(admin): Update admin banner to fit within viewport (100vh) instead of absolute positioning

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,7 +24,7 @@ export const App: React.FC = () => {
   }
 
   return (
-    <div className="w-full h-screen bg-gradient-to-br from-green-50 to-green-100 flex flex-col">
+    <div className="w-full h-full bg-gradient-to-br from-green-50 to-green-100 flex flex-col">
       <Header />
       <AppRoutes />
       <BottomNavigation />

--- a/frontend/src/components/AdminWrapper.tsx
+++ b/frontend/src/components/AdminWrapper.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useAdminStore } from '../stores/adminStore'
 import { useAuthStore } from '../stores/authStore'
 import { getCurrentEnvironment } from '../hooks/useFeatureToggle'
 import { useNavigate } from 'react-router'
 import { Settings, AlertTriangle, LogOut, User } from 'lucide-react'
 import { COPY } from '../constants/copy'
-import { zIndex } from '../styles/spacing'
 
 interface AdminWrapperProps {
   children: React.ReactNode
@@ -22,18 +21,6 @@ export const AdminWrapper: React.FC<AdminWrapperProps> = ({ children }) => {
   // Show banner if in dev mode with admin mode active, or if authenticated as admin
   const showBanner = (currentEnv === 'dev' && adminModeActive) || (isAuthenticated && user?.role === 'admin')
 
-  // Add CSS variable to document root for banner height
-  useEffect(() => {
-    if (showBanner) {
-      document.documentElement.style.setProperty('--admin-banner-height', `${ADMIN_BANNER_HEIGHT}px`)
-    } else {
-      document.documentElement.style.setProperty('--admin-banner-height', '0px')
-    }
-
-    return () => {
-      document.documentElement.style.setProperty('--admin-banner-height', '0px')
-    }
-  }, [showBanner])
 
   // Only show wrapper in actual dev environment (not simulated prod mode)
   if (!showBanner) {
@@ -62,13 +49,12 @@ export const AdminWrapper: React.FC<AdminWrapperProps> = ({ children }) => {
   }
 
   return (
-    <>
-      {/* Admin Control Bar - Fixed at top with exact height, amber warning color for admin mode */}
+    <div className="w-full h-screen flex flex-col">
+      {/* Admin Control Bar - Part of document flow, amber warning color for admin mode */}
       <div
-        className={`fixed top-0 left-0 right-0 w-full ${isAuthenticated ? 'bg-amber-600' : isProdMode ? 'bg-red-600' : 'bg-purple-600'} text-white px-4 shadow-lg flex items-center justify-between`}
+        className={`w-full ${isAuthenticated ? 'bg-amber-600' : isProdMode ? 'bg-red-600' : 'bg-purple-600'} text-white px-4 shadow-lg flex items-center justify-between flex-shrink-0`}
         style={{ 
           height: `${ADMIN_BANNER_HEIGHT}px`,
-          zIndex: zIndex.adminBanner 
         }}
       >
         <div className="flex items-center gap-4">
@@ -154,12 +140,11 @@ export const AdminWrapper: React.FC<AdminWrapperProps> = ({ children }) => {
         </div>
       </div>
 
-      {/* Spacer for fixed bar with exact height */}
-      <div style={{ height: `${ADMIN_BANNER_HEIGHT}px` }} />
-
-      {/* App Content */}
-      {children}
-    </>
+      {/* App Content - Takes remaining space */}
+      <div className="flex-1 min-h-0">
+        {children}
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
Fixes the admin banner positioning issue where absolute positioning caused total height to exceed 100vh and introduce unwanted scrolling.

## Changes
- Changed AdminWrapper from `position:fixed` to flexbox layout
- Admin banner now part of normal document flow (flex-shrink-0)
- App content takes remaining space (flex-1 min-h-0)
- Removed spacer div and CSS variable logic (no longer needed)
- Total height now fits within 100vh without unwanted scrolling
- Maintains 44px banner height and amber warning color
- Preserves mobile responsiveness and touch targets

Closes #83

🤖 Generated with [Claude Code](https://claude.ai/code)