### PR TITLE
fix(admin): correctly handle numeric 0 values in missing fields indicator

### DIFF
--- a/frontend/src/components/admin/CafeManagementPage.tsx
+++ b/frontend/src/components/admin/CafeManagementPage.tsx
@@ -31,6 +31,14 @@ export const CafeManagementPage: React.FC = () => {
       return OPTIONAL_CAFE_FIELDS
         .filter(field => {
           const value = cafe[field.key as keyof Cafe]
+          
+          // For numeric fields (chargeForAltMilk, ambianceScore), 0 is valid
+          const isNumericField = field.key === 'ambianceScore' || field.key === 'chargeForAltMilk'
+          if (isNumericField) {
+            return value === null || value === undefined
+          }
+          
+          // For string fields, null/undefined/empty are all missing
           return value === null || value === undefined || value === ''
         })
         .map(field => field.label)


### PR DESCRIPTION
Previously, the missing fields indicator treated numeric 0 values as missing data.

Now distinguishes between numeric fields (ambianceScore, chargeForAltMilk) where 0 is valid, and string fields where empty string indicates missing data.

Fixes #109

🤖 Generated with [Claude Code](https://claude.ai/code)