### PR TITLE
normalize city configs

### DIFF
--- a/.claude/commands/add-city.md
+++ b/.claude/commands/add-city.md
@@ -1,0 +1,148 @@
+---
+description: Add a new city to MatchaMap (updates shared types and city store)
+args:
+  - name: city_key
+    description: City key in lowercase (e.g., vancouver, los-angeles, san-francisco)
+    required: true
+  - name: city_name
+    description: Display name (e.g., "Vancouver", "Los Angeles", "San Francisco")
+    required: true
+  - name: short_code
+    description: 2-3 letter code (e.g., VAN, LA, SF)
+    required: true
+  - name: latitude
+    description: City center latitude (e.g., 49.2827)
+    required: true
+  - name: longitude
+    description: City center longitude (e.g., -123.1207)
+    required: true
+---
+
+Add a new city to MatchaMap by updating the shared types and city store configuration.
+
+## Steps to Complete
+
+### 1. Add to Shared Types (VALID_CITY_KEYS)
+
+Update `shared/types/index.ts`:
+
+```typescript
+export const VALID_CITY_KEYS = [
+  'toronto',
+  'montreal',
+  'new york',
+  'mississauga',
+  'scarborough',
+  'tokyo',
+  'kyoto',
+  'osaka',
+  '{{city_key}}', // ← ADD THIS LINE (keep alphabetical order if preferred)
+] as const
+```
+
+**Important:**
+- City key MUST be lowercase
+- Use spaces for multi-word cities (e.g., `'new york'`, `'los angeles'`)
+- Keep the format consistent with existing keys
+
+### 2. Add City Configuration to Frontend
+
+Update `frontend/src/stores/cityStore.ts`:
+
+Add to the `CITIES` constant:
+
+```typescript
+export const CITIES: Record<CityKey, City> = {
+  // ... existing cities
+  '{{city_key}}': {
+    key: '{{city_key}}',
+    name: '{{city_name}}',
+    shortCode: '{{short_code}}',
+    center: [{{latitude}}, {{longitude}}],
+    zoom: 13, // Default zoom level (adjust if needed: 11=country, 13=city, 15=neighborhood)
+  },
+}
+```
+
+**Map Center Tips:**
+- Use the approximate city center (downtown area)
+- Find coordinates: https://www.latlong.net/
+- Zoom levels:
+  - `11` = Wide view (country/region)
+  - `13` = City view (recommended default)
+  - `15` = Neighborhood view
+
+### 3. Verify Changes
+
+After making the updates:
+
+1. **Type check:** `npm run typecheck`
+2. **Build:** `npm run build`
+3. **Test locally:** Start dev server and verify:
+   - Admin UI shows new city in dropdown
+   - Map city selector includes new city
+   - List view city filter includes new city
+
+### 4. Deploy
+
+```bash
+git add shared/types/index.ts frontend/src/stores/cityStore.ts
+git commit -m "feat(cities): add {{city_name}}"
+git push
+```
+
+Cloudflare Pages will auto-deploy in 1-2 minutes.
+
+### 5. Add Cafes
+
+Once deployed:
+1. Login to admin UI
+2. Click "Add New Cafe"
+3. Select "{{city_name}}" from city dropdown
+4. Add cafe details and save
+
+## What Gets Updated Automatically
+
+When you add a city using this process:
+- ✅ Admin UI dropdown (all cafe forms)
+- ✅ Map city selector
+- ✅ List view city filter (desktop + mobile)
+- ✅ `/api/cities` endpoint (once cafes are added)
+- ✅ Backend validation (prevents invalid city keys)
+- ✅ TypeScript type safety
+
+## Example Usage
+
+```bash
+/add-city vancouver "Vancouver" VAN 49.2827 -123.1207
+/add-city "los angeles" "Los Angeles" LA 34.0522 -118.2437
+/add-city "san francisco" "San Francisco" SF 37.7749 -122.4194
+```
+
+## Notes
+
+- **City keys with spaces:** Use quotes in the slash command (e.g., `"los angeles"`)
+- **No database changes needed:** Cities are code-controlled for type safety
+- **Case sensitive:** Always use lowercase for city keys
+- **Validation:** Backend automatically validates new cafes against VALID_CITY_KEYS
+
+## Troubleshooting
+
+**TypeScript errors after adding city?**
+- Make sure city key is in VALID_CITY_KEYS
+- Verify key matches exactly between shared types and city store
+- Run `npm run typecheck` to see specific errors
+
+**City not showing in dropdowns?**
+- Clear browser cache
+- Verify build succeeded (`npm run build`)
+- Check both files were updated correctly
+
+**Backend rejecting new cafe?**
+- Ensure city key is in VALID_CITY_KEYS (shared/types/index.ts)
+- Check backend logs for validation error message
+- Verify key is lowercase and matches exactly
+
+---
+
+**Related Documentation:** `docs/adding-new-cities.md`

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,11 +4,11 @@ Backend API for MatchaMap built with Cloudflare Workers, D1 Database, and Drizzl
 
 ## Tech Stack
 
-- **Runtime**: Cloudflare Workers
-- **Database**: Cloudflare D1 (SQLite at the edge)
-- **Router**: itty-router (450 bytes)
-- **ORM**: Drizzle ORM
-- **TypeScript**: Strict mode enabled
+-   **Runtime**: Cloudflare Workers
+-   **Database**: Cloudflare D1 (SQLite at the edge)
+-   **Router**: itty-router (450 bytes)
+-   **ORM**: Drizzle ORM
+-   **TypeScript**: Strict mode enabled
 
 ## Project Structure
 
@@ -113,18 +113,18 @@ The API will be available at `http://localhost:8787`
 
 1. Edit `drizzle/schema.ts`
 2. Generate migration:
-   ```bash
-   npm run db:generate
-   ```
+    ```bash
+    npm run db:generate
+    ```
 3. Apply migration locally:
-   ```bash
-   npm run db:migrate:local
-   ```
+    ```bash
+    npm run db:migrate:local
+    ```
 4. Test changes
 5. Apply to production:
-   ```bash
-   npm run db:migrate:prod
-   ```
+    ```bash
+    npm run db:migrate:prod
+    ```
 
 ### Testing Locally
 
@@ -164,18 +164,18 @@ wrangler rollback
 
 ### Public Endpoints (No Auth)
 
-- `GET /api/health` - Health check
-- `GET /api/cafes` - List cafes (with filters: city, neighborhood, minScore, maxPrice, limit, offset)
-- `GET /api/cafes/:id` - Get single cafe with drinks
-- `GET /api/neighborhoods` - List neighborhoods with cafe counts
-- `GET /api/feed` - List feed items (with filters: type, limit, offset)
-- `GET /api/events` - List events (with filters: upcoming, featured, limit)
+-   `GET /api/health` - Health check
+-   `GET /api/cafes` - List cafes (with filters: city, neighborhood, minScore, maxPrice, limit, offset)
+-   `GET /api/cafes/:id` - Get single cafe with drinks
+-   `GET /api/neighborhoods` - List neighborhoods with cafe counts
+-   `GET /api/feed` - List feed items (with filters: type, limit, offset)
+-   `GET /api/events` - List events (with filters: upcoming, featured, limit)
 
 ### Admin Endpoints (Cloudflare Access Required)
 
-- `POST /api/admin/cafes` - Create cafe
-- `PUT /api/admin/cafes/:id` - Update cafe
-- `DELETE /api/admin/cafes/:id` - Soft delete cafe
+-   `POST /api/admin/cafes` - Create cafe
+-   `PUT /api/admin/cafes/:id` - Update cafe
+-   `DELETE /api/admin/cafes/:id` - Soft delete cafe
 
 ## Environment Variables
 
@@ -184,24 +184,24 @@ Set in `wrangler.toml`:
 ```toml
 [vars]
 ENVIRONMENT = "development"
-ALLOWED_ORIGINS = "http://localhost:5173,https://matchamap.club,https://*.matchamap.club"
+ALLOWED_ORIGINS = "http://localhost:3000,https://matchamap.club,https://*.matchamap.club"
 ```
 
 ## Database Schema
 
 See `drizzle/schema.ts` for the complete schema. Main tables:
 
-- `cafes` - Cafe locations and details
-- `drinks` - Drink menu items
-- `neighborhoods` - Neighborhood boundaries
-- `feed_items` - News feed content
-- `events` - Upcoming events
+-   `cafes` - Cafe locations and details
+-   `drinks` - Drink menu items
+-   `neighborhoods` - Neighborhood boundaries
+-   `feed_items` - News feed content
+-   `events` - Upcoming events
 
 ## Caching Strategy
 
-- Public endpoints: `Cache-Control: public, max-age=300` (5 min)
-- Admin endpoints: `Cache-Control: no-store`
-- ETags supported on GET requests
+-   Public endpoints: `Cache-Control: public, max-age=300` (5 min)
+-   Admin endpoints: `Cache-Control: no-store`
+-   ETags supported on GET requests
 
 ## CORS Configuration
 
@@ -239,7 +239,7 @@ Check migration files in `drizzle/migrations/` for SQL syntax errors.
 
 ## Resources
 
-- [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
-- [Drizzle ORM Docs](https://orm.drizzle.team/)
-- [itty-router Docs](https://itty.dev/)
-- [D1 Database Docs](https://developers.cloudflare.com/d1/)
+-   [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
+-   [Drizzle ORM Docs](https://orm.drizzle.team/)
+-   [itty-router Docs](https://itty.dev/)
+-   [D1 Database Docs](https://developers.cloudflare.com/d1/)

--- a/backend/drizzle/migrations/0009_normalize_city_keys.sql
+++ b/backend/drizzle/migrations/0009_normalize_city_keys.sql
@@ -1,0 +1,16 @@
+-- Migration: Normalize city keys to match CITIES constant
+-- Purpose: Ensure database city values exactly match frontend CityKey type
+-- Date: 2025-10-10
+
+-- Normalize "new york city" to "new york"
+UPDATE cafes
+SET city = 'new york'
+WHERE LOWER(city) = 'new york city';
+
+-- Ensure all other cities are lowercase (idempotent)
+UPDATE cafes
+SET city = LOWER(city)
+WHERE city != LOWER(city);
+
+-- Verify results (optional - for logging)
+-- SELECT city, COUNT(*) as count FROM cafes WHERE deleted_at IS NULL GROUP BY city ORDER BY count DESC;

--- a/backend/src/routes/cafes.ts
+++ b/backend/src/routes/cafes.ts
@@ -11,6 +11,7 @@ import {
 import { HTTP_STATUS, PAGINATION_CONSTANTS, CACHE_CONSTANTS } from '../constants';
 import { logAdminAction, generateChangesSummary } from '../utils/auditLog';
 import { AuthenticatedRequest } from '../middleware/auth';
+import { VALID_CITY_KEYS } from '../../../shared/types';
 
 // GET /api/cafes - List cafes with optional filtering
 export async function listCafes(request: IRequest, env: Env): Promise<Response> {
@@ -160,6 +161,16 @@ export async function createCafe(request: IRequest, env: Env): Promise<Response>
       return badRequestResponse('Missing required fields', request as Request, env);
     }
 
+    // Validate city key
+    const cityKey = (body.city || 'toronto').toLowerCase();
+    if (!VALID_CITY_KEYS.includes(cityKey as any)) {
+      return badRequestResponse(
+        `Invalid city. Must be one of: ${VALID_CITY_KEYS.join(', ')}`,
+        request as Request,
+        env
+      );
+    }
+
     const db = getDb(env.DB);
     const slug = body.slug || body.name.toLowerCase().replace(/\s+/g, '-');
 
@@ -177,7 +188,7 @@ export async function createCafe(request: IRequest, env: Env): Promise<Response>
       address: body.address || null,
       latitude: body.latitude,
       longitude: body.longitude,
-      city: (body.city || 'toronto').toLowerCase(), // Normalize to lowercase
+      city: cityKey, // Already validated and normalized
       ambianceScore: body.ambianceScore ?? null,
       chargeForAltMilk: body.chargeForAltMilk ?? null,
       quickNote: body.quickNote,
@@ -289,7 +300,17 @@ export async function updateCafe(request: IRequest, env: Env): Promise<Response>
     if (body.address !== undefined) updateData.address = body.address || null;
     if (body.latitude !== undefined) updateData.latitude = body.latitude;
     if (body.longitude !== undefined) updateData.longitude = body.longitude;
-    if (body.city !== undefined) updateData.city = body.city.toLowerCase(); // Normalize to lowercase
+    if (body.city !== undefined) {
+      const cityKey = body.city.toLowerCase();
+      if (!VALID_CITY_KEYS.includes(cityKey as any)) {
+        return badRequestResponse(
+          `Invalid city. Must be one of: ${VALID_CITY_KEYS.join(', ')}`,
+          request as Request,
+          env
+        );
+      }
+      updateData.city = cityKey;
+    }
 
     // Ratings
     if (body.ambianceScore !== undefined) updateData.ambianceScore = body.ambianceScore ?? null;

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -17,7 +17,7 @@ migrations_dir = "drizzle/migrations"
 # Production environment variables (default)
 [vars]
 ENVIRONMENT = "production"
-ALLOWED_ORIGINS = "https://matchamap.club,https://*.matchamap.club,https://matchamap.pages.dev,https://*.matchamap.pages.dev,http://localhost:3000,http://localhost:5173,http://localhost:5174"
+ALLOWED_ORIGINS = "https://matchamap.club,https://*.matchamap.club,https://matchamap.pages.dev,https://*.matchamap.pages.dev,http://localhost:3000,http://localhost:5174"
 
 # SECURITY: Required secrets (set via Wrangler CLI)
 # NEVER commit secrets to git - they must be set via Wrangler CLI:
@@ -35,7 +35,7 @@ ALLOWED_ORIGINS = "https://matchamap.club,https://*.matchamap.club,https://match
 # Development environment (for testing deployments before production)
 [env.dev]
 name = "matchamap-api-dev"
-vars = { ENVIRONMENT = "development", ALLOWED_ORIGINS = "http://localhost:3000,http://localhost:5173,http://localhost:5174" }
+vars = { ENVIRONMENT = "development", ALLOWED_ORIGINS = "http://localhost:3000" }
 
 # SECURITY: Development secrets must also be set via Wrangler CLI
 # Do not use hardcoded secrets even in development

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -31,15 +31,17 @@ MatchaMap deploys to Cloudflare's edge infrastructure for zero-latency global pe
 ## Prerequisites
 
 ### Required Tools
-- **Node.js**: 18.x or later
-- **npm**: 9.x or later
-- **Wrangler CLI**: `npm install -g wrangler`
-- **Git**: For version control
+
+-   **Node.js**: 18.x or later
+-   **npm**: 9.x or later
+-   **Wrangler CLI**: `npm install -g wrangler`
+-   **Git**: For version control
 
 ### Cloudflare Account
-- Sign up at https://dash.cloudflare.com
-- Free tier is sufficient for V1
-- No credit card required for development
+
+-   Sign up at https://dash.cloudflare.com
+-   Free tier is sufficient for V1
+-   No credit card required for development
 
 ## Local Development
 
@@ -49,7 +51,7 @@ MatchaMap deploys to Cloudflare's edge infrastructure for zero-latency global pe
 # Start React dev server
 npm run dev
 
-# Runs on http://localhost:5173
+# Runs on http://localhost:3000
 # Hot module reloading enabled
 # Points to local Workers API (if running)
 ```
@@ -84,20 +86,22 @@ cd workers && npm run dev
 ### Initial Setup
 
 1. **Connect Repository**
-   ```bash
-   # Via Cloudflare Dashboard:
-   Pages → Create Project → Connect to Git
-   Select: GitHub/GitLab repository
-   ```
+
+    ```bash
+    # Via Cloudflare Dashboard:
+    Pages → Create Project → Connect to Git
+    Select: GitHub/GitLab repository
+    ```
 
 2. **Build Configuration**
-   ```
-   Framework preset: Vite
-   Build command: npm run build
-   Build output directory: dist
-   Root directory: /
-   Branch: main
-   ```
+
+    ```
+    Framework preset: Vite
+    Build command: npm run build
+    Build output directory: dist
+    Root directory: /
+    Branch: main
+    ```
 
 3. **Environment Variables** (none needed for V1)
 
@@ -225,38 +229,41 @@ ENVIRONMENT = "staging"
 ### Frontend Domain
 
 1. **Add Custom Domain** (Cloudflare Pages Dashboard)
-   ```
-   Pages → Settings → Custom Domains
-   Add: matchamap.com
-   ```
+
+    ```
+    Pages → Settings → Custom Domains
+    Add: matchamap.com
+    ```
 
 2. **DNS Configuration** (automatic if using Cloudflare DNS)
-   ```
-   Type: CNAME
-   Name: @
-   Target: matchamap.pages.dev
-   Proxy: Enabled
-   ```
+
+    ```
+    Type: CNAME
+    Name: @
+    Target: matchamap.pages.dev
+    Proxy: Enabled
+    ```
 
 3. **SSL Certificate**
-   - Automatic via Cloudflare Universal SSL
-   - Active within minutes
+    - Automatic via Cloudflare Universal SSL
+    - Active within minutes
 
 ### API Domain
 
 1. **Add Route** (Workers Dashboard)
-   ```
-   Workers → matchamap-api → Triggers
-   Add Route: api.matchamap.com/*
-   ```
+
+    ```
+    Workers → matchamap-api → Triggers
+    Add Route: api.matchamap.com/*
+    ```
 
 2. **DNS Configuration**
-   ```
-   Type: CNAME
-   Name: api
-   Target: matchamap.com
-   Proxy: Enabled
-   ```
+    ```
+    Type: CNAME
+    Name: api
+    Target: matchamap.com
+    Proxy: Enabled
+    ```
 
 ## Cloudflare Access (Admin Protection)
 
@@ -333,8 +340,8 @@ Workers → matchamap-api → Analytics
 
 ```typescript
 // Track custom events
-analytics.track('cafe_view', { cafeId: 42 })
-analytics.track('directions_click', { cafeId: 42 })
+analytics.track("cafe_view", { cafeId: 42 });
+analytics.track("directions_click", { cafeId: 42 });
 ```
 
 ## CI/CD Pipeline
@@ -346,31 +353,31 @@ analytics.track('directions_click', { cafeId: 42 })
 name: Deploy to Cloudflare
 
 on:
-  push:
-    branches: [main]
+    push:
+        branches: [main]
 
 jobs:
-  deploy-frontend:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-      - run: npm install
-      - run: npm run build
-      - uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: matchamap
+    deploy-frontend:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+            - run: npm install
+            - run: npm run build
+            - uses: cloudflare/pages-action@v1
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  projectName: matchamap
 
-  deploy-workers:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: cd workers && npm install
-      - run: cd workers && npm run deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    deploy-workers:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - run: cd workers && npm install
+            - run: cd workers && npm run deploy
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
 
 ## Troubleshooting
@@ -503,39 +510,44 @@ npx wrangler d1 execute matchamap-db --file=migrations/rollback.sql
 ## Production Checklist
 
 ### Pre-Launch
-- [ ] Frontend builds successfully
-- [ ] Workers deploy successfully
-- [ ] Database migrations applied
-- [ ] Custom domain configured
-- [ ] SSL certificate active
-- [ ] Admin routes protected (Cloudflare Access)
-- [ ] Analytics configured
-- [ ] Performance tested (Lighthouse > 90)
-- [ ] Mobile tested on real devices
+
+-   [ ] Frontend builds successfully
+-   [ ] Workers deploy successfully
+-   [ ] Database migrations applied
+-   [ ] Custom domain configured
+-   [ ] SSL certificate active
+-   [ ] Admin routes protected (Cloudflare Access)
+-   [ ] Analytics configured
+-   [ ] Performance tested (Lighthouse > 90)
+-   [ ] Mobile tested on real devices
 
 ### Post-Launch
-- [ ] Monitoring dashboards configured
-- [ ] Backup cron job running
-- [ ] Error alerting setup
-- [ ] Team access configured
-- [ ] Documentation updated
+
+-   [ ] Monitoring dashboards configured
+-   [ ] Backup cron job running
+-   [ ] Error alerting setup
+-   [ ] Team access configured
+-   [ ] Documentation updated
 
 ## Maintenance
 
 ### Daily
-- Monitor Cloudflare Analytics
-- Check error rates in Workers
+
+-   Monitor Cloudflare Analytics
+-   Check error rates in Workers
 
 ### Weekly
-- Review performance metrics
-- Check database size
-- Update content via admin UI
+
+-   Review performance metrics
+-   Check database size
+-   Update content via admin UI
 
 ### Monthly
-- Dependency updates
-- Security patches
-- Database backup verification
-- Cost review (should be $0)
+
+-   Dependency updates
+-   Security patches
+-   Database backup verification
+-   Cost review (should be $0)
 
 ---
 

--- a/docs/DEPLOYMENT_COMMANDS.md
+++ b/docs/DEPLOYMENT_COMMANDS.md
@@ -104,11 +104,13 @@ wrangler whoami
 ## Testing Production Endpoints
 
 ### Health Check
+
 ```bash
 curl https://matchamap-api-production.kevingeng33.workers.dev/api/health
 ```
 
 ### Test API Endpoints
+
 ```bash
 # Get cafes
 curl https://matchamap-api-production.kevingeng33.workers.dev/api/cafes
@@ -118,6 +120,7 @@ curl https://matchamap-api-production.kevingeng33.workers.dev/api/events
 ```
 
 ### Test Admin Endpoint (requires auth)
+
 ```bash
 curl -H "Authorization: Bearer YOUR_JWT_TOKEN" \
   https://matchamap-api-production.kevingeng33.workers.dev/api/admin/cafes
@@ -172,41 +175,48 @@ cd frontend && npm run lint
 ## Important URLs
 
 ### Production
-- **Frontend**: https://matchamap.pages.dev
-- **API**: https://matchamap-api-production.kevingeng33.workers.dev
-- **Health Check**: https://matchamap-api-production.kevingeng33.workers.dev/api/health
+
+-   **Frontend**: https://matchamap.pages.dev
+-   **API**: https://matchamap-api-production.kevingeng33.workers.dev
+-   **Health Check**: https://matchamap-api-production.kevingeng33.workers.dev/api/health
 
 ### Development
-- **Frontend**: http://localhost:5173
-- **API**: http://localhost:8787
-- **Health Check**: http://localhost:8787/api/health
+
+-   **Frontend**: http://localhost:3000
+-   **API**: http://localhost:8787
+-   **Health Check**: http://localhost:8787/api/health
 
 ## Configuration Files
 
 ### Backend Configuration
-- **Wrangler Config**: `backend/wrangler.toml`
-- **Environment Variables**: Set via `wrangler secret put`
-- **Database Schema**: `backend/drizzle/schema.ts`
+
+-   **Wrangler Config**: `backend/wrangler.toml`
+-   **Environment Variables**: Set via `wrangler secret put`
+-   **Database Schema**: `backend/drizzle/schema.ts`
 
 ### Frontend Configuration
-- **Production API URL**: `frontend/.env.production`
-- **Feature Flags**: `frontend/src/config/features.yaml`
+
+-   **Production API URL**: `frontend/.env.production`
+-   **Feature Flags**: `frontend/src/config/features.yaml`
 
 ## Troubleshooting Commands
 
 ### Check Worker Logs
+
 ```bash
 cd backend
 wrangler tail --env production
 ```
 
 ### Verify D1 Database Binding
+
 ```bash
 # Check if database is properly bound to worker
 wrangler deployments list --env production
 ```
 
 ### Test CORS
+
 ```bash
 curl -H "Origin: https://matchamap.pages.dev" \
   -H "Access-Control-Request-Method: GET" \
@@ -217,15 +227,15 @@ curl -H "Origin: https://matchamap.pages.dev" \
 
 ## Security Checklist Before Production Deploy
 
-- [ ] JWT_SECRET set via `wrangler secret put` (never in code)
-- [ ] D1 database bound to production worker
-- [ ] Migrations run on production database
-- [ ] CORS origins configured correctly in wrangler.toml
-- [ ] HTTPS enforcement enabled (automatic in production)
-- [ ] Rate limiting configured
-- [ ] Admin routes protected with JWT + role check
-- [ ] Input validation (Zod schemas) in place
-- [ ] Security headers configured
+-   [ ] JWT_SECRET set via `wrangler secret put` (never in code)
+-   [ ] D1 database bound to production worker
+-   [ ] Migrations run on production database
+-   [ ] CORS origins configured correctly in wrangler.toml
+-   [ ] HTTPS enforcement enabled (automatic in production)
+-   [ ] Rate limiting configured
+-   [ ] Admin routes protected with JWT + role check
+-   [ ] Input validation (Zod schemas) in place
+-   [ ] Security headers configured
 
 ## Quick Deploy Checklist
 

--- a/docs/GOOGLE_PLACES_SETUP.md
+++ b/docs/GOOGLE_PLACES_SETUP.md
@@ -26,21 +26,23 @@
 ### 4. Restrict the API Key (Security)
 
 **Restrict which APIs can use this key:**
+
 1. Under "API restrictions", select "Restrict key"
 2. Check only: **Places API (New)**
 3. Click Save
 
 **Add HTTP referrer restrictions (optional for local dev):**
-- For local development: No restrictions needed
-- For production: Add your domain (e.g., `https://matchamap.pages.dev/*`)
+
+-   For local development: No restrictions needed
+-   For production: Add your domain (e.g., `https://matchamap.pages.dev/*`)
 
 ### 5. Add API Key to Your Project
 
 1. Open `backend/wrangler.toml`
 2. Replace `YOUR_API_KEY_HERE` with your actual API key:
-   ```toml
-   GOOGLE_PLACES_API_KEY = "AIzaSy..."
-   ```
+    ```toml
+    GOOGLE_PLACES_API_KEY = "AIzaSy..."
+    ```
 3. Save the file
 
 ### 6. Restart Your Backend Server
@@ -54,7 +56,7 @@ That's it! The Google Maps lookup feature is now enabled.
 
 ## Testing the Integration
 
-1. Go to your admin panel: http://localhost:5173/admin/cafes
+1. Go to your admin panel: http://localhost:3000/admin/cafes
 2. Click "Add New Cafe"
 3. Paste a Google Maps URL (e.g., `https://www.google.com/maps/place/...`)
 4. Click Continue
@@ -70,33 +72,37 @@ That's it! The Google Maps lookup feature is now enabled.
 6. **Important**: Use the full URL, not shortened goo.gl links
 
 Example URL format:
+
 ```
 https://www.google.com/maps/place/Cafe+Name/@43.6532,-79.3832,17z/data=...!1sChIJ...
 ```
 
 ## Pricing
 
-- **Free tier**: $200/month credit (renews monthly)
-- **Cost per lookup**: ~$0.04-0.05 per cafe
-- **Your usage**: If adding 20 cafes/month = $1/month (well within free tier!)
+-   **Free tier**: $200/month credit (renews monthly)
+-   **Cost per lookup**: ~$0.04-0.05 per cafe
+-   **Your usage**: If adding 20 cafes/month = $1/month (well within free tier!)
 
 You'll never pay anything unless you add 4000+ cafes in a single month.
 
 ## Troubleshooting
 
 ### "Could not extract place ID from URL"
-- Make sure you're using the full Google Maps URL
-- Avoid shortened goo.gl links (they won't work)
-- The URL should contain place data (click "Share" to get the right URL)
+
+-   Make sure you're using the full Google Maps URL
+-   Avoid shortened goo.gl links (they won't work)
+-   The URL should contain place data (click "Share" to get the right URL)
 
 ### "Google Places API returned 403"
-- Check that Places API (New) is enabled in Google Cloud Console
-- Verify your API key is correct in wrangler.toml
-- Make sure the API key has Places API (New) enabled
+
+-   Check that Places API (New) is enabled in Google Cloud Console
+-   Verify your API key is correct in wrangler.toml
+-   Make sure the API key has Places API (New) enabled
 
 ### "Google Places API returned 400"
-- The place ID might be invalid
-- Try getting a fresh URL from Google Maps
+
+-   The place ID might be invalid
+-   Try getting a fresh URL from Google Maps
 
 ## Need Help?
 

--- a/docs/TECH_SPEC.md
+++ b/docs/TECH_SPEC.md
@@ -39,31 +39,35 @@ MatchaMap is a full-stack React application with Cloudflare edge infrastructure,
 ## Technical Stack
 
 ### Frontend
-- **Framework**: React 18.3+
-- **Build Tool**: Vite 5.x
-- **Routing**: React Router 6.x
-- **State**: Zustand (lightweight global state)
-- **Styling**: Tailwind CSS 3.x
-- **Maps**: Leaflet 1.9.x
-- **Language**: TypeScript (strict mode)
+
+-   **Framework**: React 18.3+
+-   **Build Tool**: Vite 5.x
+-   **Routing**: React Router 6.x
+-   **State**: Zustand (lightweight global state)
+-   **Styling**: Tailwind CSS 3.x
+-   **Maps**: Leaflet 1.9.x
+-   **Language**: TypeScript (strict mode)
 
 ### Backend
-- **Runtime**: Cloudflare Workers
-- **Router**: itty-router (~450 bytes)
-- **ORM**: Drizzle ORM
-- **Migrations**: Drizzle Kit
-- **Language**: TypeScript
+
+-   **Runtime**: Cloudflare Workers
+-   **Router**: itty-router (~450 bytes)
+-   **ORM**: Drizzle ORM
+-   **Migrations**: Drizzle Kit
+-   **Language**: TypeScript
 
 ### Data
-- **Database**: Cloudflare D1 (SQLite)
-- **Storage**: Cloudflare R2 (S3-compatible)
-- **Cache**: HTTP Cache-Control headers
+
+-   **Database**: Cloudflare D1 (SQLite)
+-   **Storage**: Cloudflare R2 (S3-compatible)
+-   **Cache**: HTTP Cache-Control headers
 
 ### Hosting
-- **Frontend**: Cloudflare Pages
-- **Backend**: Cloudflare Workers
-- **CDN**: Cloudflare global network
-- **Auth**: Cloudflare Access
+
+-   **Frontend**: Cloudflare Pages
+-   **Backend**: Cloudflare Workers
+-   **CDN**: Cloudflare global network
+-   **Auth**: Cloudflare Access
 
 ## Database Schema
 
@@ -204,15 +208,17 @@ src/
 ### State Management
 
 **Zustand Stores** (global state):
-- Location data (user coordinates)
-- UI state (modals, panels)
-- City selection
-- Visited cafes (persisted to localStorage)
+
+-   Location data (user coordinates)
+-   UI state (modals, panels)
+-   City selection
+-   Visited cafes (persisted to localStorage)
 
 **Local State** (useState/useReducer):
-- Component-specific interactions
-- Form inputs
-- Temporary UI state
+
+-   Component-specific interactions
+-   Form inputs
+-   Temporary UI state
 
 ## Performance Specifications
 
@@ -242,17 +248,19 @@ CLS (Cumulative Layout Shift): < 0.1
 ### Optimization Strategies
 
 **Frontend:**
-- Code splitting by route
-- Lazy loading for map/heavy components
-- Image optimization (WebP, proper sizing)
-- Tailwind CSS purging
-- Aggressive caching (1 year for assets)
+
+-   Code splitting by route
+-   Lazy loading for map/heavy components
+-   Image optimization (WebP, proper sizing)
+-   Tailwind CSS purging
+-   Aggressive caching (1 year for assets)
 
 **Backend:**
-- Prepared SQL statements
-- Database query optimization
-- HTTP caching headers
-- Edge caching (Cloudflare CDN)
+
+-   Prepared SQL statements
+-   Database query optimization
+-   HTTP caching headers
+-   Edge caching (Cloudflare CDN)
 
 ## Mobile-First Design
 
@@ -260,24 +268,29 @@ CLS (Cumulative Layout Shift): < 0.1
 
 ```css
 /* Base: 320px-640px (mobile) */
-.container { /* mobile styles */ }
+.container {
+    /* mobile styles */
+}
 
 /* sm: 640px+ (tablet) */
-@media (min-width: 640px) { }
+@media (min-width: 640px) {
+}
 
 /* md: 768px+ (small desktop) */
-@media (min-width: 768px) { }
+@media (min-width: 768px) {
+}
 
 /* lg: 1024px+ (desktop) */
-@media (min-width: 1024px) { }
+@media (min-width: 1024px) {
+}
 ```
 
 ### Touch Interface
 
-- **Min touch target**: 44px × 44px
-- **Gestures**: Tap, scroll, pinch (map only)
-- **No hover dependencies**: All interactions work on touch
-- **Active states**: Visual feedback on all interactions
+-   **Min touch target**: 44px × 44px
+-   **Gestures**: Tap, scroll, pinch (map only)
+-   **No hover dependencies**: All interactions work on touch
+-   **Active states**: Visual feedback on all interactions
 
 ### Responsive Patterns
 
@@ -301,21 +314,21 @@ Map:
 ### Leaflet Configuration
 
 ```typescript
-const map = L.map('map', {
-  center: [43.6532, -79.3832], // Toronto
-  zoom: 12,
-  zoomControl: false,
-  scrollWheelZoom: true,
-  touchZoom: true,
-  doubleClickZoom: true,
-  boxZoom: false, // Disabled on mobile
-})
+const map = L.map("map", {
+    center: [43.6532, -79.3832], // Toronto
+    zoom: 12,
+    zoomControl: false,
+    scrollWheelZoom: true,
+    touchZoom: true,
+    doubleClickZoom: true,
+    boxZoom: false, // Disabled on mobile
+});
 
 // OpenStreetMap tiles
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  maxZoom: 18,
-  attribution: '© OpenStreetMap contributors'
-}).addTo(map)
+L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    maxZoom: 18,
+    attribution: "© OpenStreetMap contributors",
+}).addTo(map);
 ```
 
 ### Custom Markers
@@ -323,31 +336,31 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 ```typescript
 // Matcha-themed pin
 const matchaIcon = L.divIcon({
-  className: 'custom-marker',
-  html: `<div class="w-8 h-8 bg-matcha-500 rounded-full...">
+    className: "custom-marker",
+    html: `<div class="w-8 h-8 bg-matcha-500 rounded-full...">
     <div class="w-3 h-3 bg-white rounded-full"></div>
   </div>`,
-  iconSize: [32, 32],
-  iconAnchor: [16, 16]
-})
+    iconSize: [32, 32],
+    iconAnchor: [16, 16],
+});
 ```
 
 ### Geolocation
 
 ```typescript
 // Platform-specific handling
-const options = getOptimalGeolocationOptions()
+const options = getOptimalGeolocationOptions();
 
 navigator.geolocation.getCurrentPosition(
-  (position) => {
-    const { latitude, longitude } = position.coords
-    // Update map center, calculate distances
-  },
-  (error) => {
-    // Graceful fallback to city center
-  },
-  options
-)
+    (position) => {
+        const { latitude, longitude } = position.coords;
+        // Update map center, calculate distances
+    },
+    (error) => {
+        // Graceful fallback to city center
+    },
+    options
+);
 ```
 
 ## Security
@@ -376,12 +389,12 @@ Cloudflare Access protects /admin/* routes
 ```typescript
 // Zod schema validation (backend)
 const CafeSchema = z.object({
-  name: z.string().min(1).max(100),
-  lat: z.number().min(43.0).max(44.0),
-  lng: z.number().min(-80.0).max(-79.0),
-  score: z.number().min(0).max(10),
-  // ...
-})
+    name: z.string().min(1).max(100),
+    lat: z.number().min(43.0).max(44.0),
+    lng: z.number().min(-80.0).max(-79.0),
+    score: z.number().min(0).max(10),
+    // ...
+});
 ```
 
 ## Monitoring & Analytics
@@ -406,9 +419,9 @@ Backend (Workers):
 
 ```typescript
 // Frontend tracking
-trackCafeStat(cafeId, 'view')
-trackCafeStat(cafeId, 'directions')
-trackFeedClick(feedItemId)
+trackCafeStat(cafeId, "view");
+trackCafeStat(cafeId, "directions");
+trackFeedClick(feedItemId);
 
 // Backend: Simple counter increments
 // See metrics-tracking-prd.md
@@ -420,7 +433,7 @@ trackFeedClick(feedItemId)
 
 ```bash
 # Frontend
-npm run dev         # Vite dev server (http://localhost:5173)
+npm run dev         # Vite dev server (http://localhost:3000)
 
 # Backend
 cd workers && npm run dev  # Wrangler dev (http://localhost:8787)
@@ -447,15 +460,18 @@ git push origin main  # Auto-deploys frontend via Cloudflare Pages
 ## Browser Support
 
 ### Primary (testing required)
-- **iOS Safari 14+** (primary mobile target)
-- **Chrome Mobile** (latest 2 versions)
+
+-   **iOS Safari 14+** (primary mobile target)
+-   **Chrome Mobile** (latest 2 versions)
 
 ### Secondary (best effort)
-- Chrome Desktop (latest)
-- Safari Desktop (latest)
-- Firefox Desktop (latest)
+
+-   Chrome Desktop (latest)
+-   Safari Desktop (latest)
+-   Firefox Desktop (latest)
 
 ### Polyfills
+
 None required (ES2020+ baseline)
 
 ## Cost Structure
@@ -558,11 +574,11 @@ CDN:
 
 ### Features (V2+)
 
-- User accounts (Cloudflare Access)
-- User-submitted reviews
-- Advanced search
-- Multi-city expansion
-- Mobile app (React Native)
+-   User accounts (Cloudflare Access)
+-   User-submitted reviews
+-   Advanced search
+-   Multi-city expansion
+-   Mobile app (React Native)
 
 ---
 

--- a/docs/adding-new-cities.md
+++ b/docs/adding-new-cities.md
@@ -1,0 +1,196 @@
+# Adding New Cities to MatchaMap
+
+## Overview
+
+MatchaMap uses a code-based, bulletproof city management system that ensures type safety and prevents data inconsistencies.
+
+## City Key Rules
+
+1. **Database stores normalized keys only** (e.g., `"new york"`, not `"New York City"`)
+2. **All keys must be lowercase**
+3. **Keys must match exactly** between frontend `CITIES` constant and database
+4. **Backend validates all city keys** on create/update operations
+
+## How to Add a New City
+
+### Quick Method: Use Slash Command
+
+```bash
+/add-city <city_key> <city_name> <short_code> <latitude> <longitude>
+
+# Examples:
+/add-city vancouver "Vancouver" VAN 49.2827 -123.1207
+/add-city "los angeles" "Los Angeles" LA 34.0522 -118.2437
+```
+
+The slash command will guide you through the exact steps and provide the code snippets.
+
+### Manual Method
+
+### Step 1: Add to Shared Types
+
+Edit `shared/types/index.ts`:
+
+```typescript
+export const VALID_CITY_KEYS = [
+  'toronto',
+  'montreal',
+  'new york',
+  'mississauga',
+  'scarborough',
+  'tokyo',
+  'kyoto',
+  'osaka',
+  'vancouver', // ← Add new city key here
+] as const
+```
+
+### Step 2: Add City Details to Frontend
+
+Edit `frontend/src/stores/cityStore.ts`:
+
+```typescript
+export const CITIES: Record<CityKey, City> = {
+  // ... existing cities
+  vancouver: {
+    key: 'vancouver',
+    name: 'Vancouver',
+    shortCode: 'VAN',
+    center: [49.2827, -123.1207], // [latitude, longitude]
+    zoom: 13,
+  },
+}
+```
+
+### Step 3: Deploy
+
+```bash
+# Commit changes
+git add shared/types/index.ts frontend/src/stores/cityStore.ts
+git commit -m "feat(cities): add Vancouver"
+git push
+
+# Auto-deploys via Cloudflare Pages (1-2 minutes)
+```
+
+### Step 4: Add Cafes
+
+Once deployed:
+1. Login to admin UI
+2. "Add New Cafe" dropdown will now include Vancouver
+3. Create cafes with `city: "vancouver"`
+
+## Architecture
+
+### Type Safety Flow
+
+```
+┌─────────────────────────────────────┐
+│ shared/types/index.ts               │
+│ - VALID_CITY_KEYS (source of truth) │
+│ - CityKey type                      │
+└───────────┬─────────────────────────┘
+            │
+    ┌───────┴────────┐
+    │                │
+    ▼                ▼
+┌───────────┐  ┌──────────────┐
+│ Backend   │  │ Frontend     │
+│ Validates │  │ CITIES const │
+│ on write  │  │ Display info │
+└───────────┘  └──────────────┘
+```
+
+### Data Flow
+
+1. **Admin creates cafe** → Backend validates city key against `VALID_CITY_KEYS`
+2. **Database stores** → Normalized lowercase key (e.g., `"vancouver"`)
+3. **API returns** → Exact database value (already normalized)
+4. **Frontend displays** → Maps key to `CITIES[key].name` (e.g., "Vancouver")
+5. **Filters work** → Direct string comparison (no normalization needed)
+
+## What Gets Updated Automatically
+
+When you add a city:
+- ✅ Admin UI dropdown (all 3 admin forms)
+- ✅ Map city selector
+- ✅ List view city filter (desktop + mobile)
+- ✅ `/api/cities` endpoint (once cafes exist)
+- ✅ Type safety (TypeScript enforces valid keys)
+
+## Validation
+
+### Backend Validation
+
+```typescript
+// backend/src/routes/cafes.ts
+if (!VALID_CITY_KEYS.includes(cityKey as any)) {
+  return badRequestResponse(
+    `Invalid city. Must be one of: ${VALID_CITY_KEYS.join(', ')}`,
+    request,
+    env
+  );
+}
+```
+
+### Frontend Type Safety
+
+```typescript
+// TypeScript prevents this:
+const invalidCity: CityKey = "invalid" // ❌ Compile error
+
+// TypeScript allows this:
+const validCity: CityKey = "vancouver" // ✅ Works
+```
+
+## Migration History
+
+### 2025-10-10: Normalized City Keys
+
+**Migration:** `0009_normalize_city_keys.sql`
+- Converted `"new york city"` → `"new york"`
+- Lowercased all city values
+- Established bulletproof normalization
+
+## FAQs
+
+### Can admins add cities via UI?
+
+No. Cities are code-controlled for:
+- Type safety (TypeScript)
+- Data integrity (validated keys)
+- Simplicity (no complex admin UI)
+- Performance (static configuration)
+
+Adding a city takes ~5 minutes of dev work.
+
+### What if a city name has spaces?
+
+Use lowercase with spaces in the key:
+```typescript
+'new york': { name: 'New York', ... }
+'los angeles': { name: 'Los Angeles', ... }
+```
+
+### Can we rename a city?
+
+Yes, but requires a migration:
+```sql
+UPDATE cafes SET city = 'new-name' WHERE city = 'old-name';
+```
+
+Then update `VALID_CITY_KEYS` and `CITIES` constant.
+
+### What about internationalization?
+
+City names in `CITIES.name` can be translated in the future via i18n. Keys remain English lowercase.
+
+## Related Files
+
+- `shared/types/index.ts` - City key source of truth
+- `frontend/src/stores/cityStore.ts` - City display config
+- `frontend/src/components/admin/CafeFormWizard.tsx` - Admin dropdown
+- `frontend/src/components/MapView.tsx` - Map city selector
+- `frontend/src/components/ListView.tsx` - List city filter
+- `backend/src/routes/cafes.ts` - City validation
+- `backend/drizzle/migrations/0009_normalize_city_keys.sql` - Normalization migration

--- a/frontend/src/components/ListView.tsx
+++ b/frontend/src/components/ListView.tsx
@@ -159,8 +159,9 @@ export const ListView: React.FC<ListViewProps> = ({ cafes, expandedCard, onToggl
       }
 
       // City filter (multi-select)
+      // City keys are already normalized in database, no need to toLowerCase
       if (filters.selectedCities.length > 0) {
-        if (!cafe.city || !filters.selectedCities.includes(cafe.city.toLowerCase() as CityKey)) {
+        if (!cafe.city || !filters.selectedCities.includes(cafe.city as CityKey)) {
           return false
         }
       }

--- a/frontend/src/components/admin/CafeFormWizard.tsx
+++ b/frontend/src/components/admin/CafeFormWizard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { X, Save, MapPin, Star, Coffee, ArrowRight, ArrowLeft, Search } from 'lucide-react'
 import { api } from '../../utils/api'
 import { formatHoursList } from '../../utils/formatHours'
+import { CITIES, CityKey } from '../../stores/cityStore'
 import type { Cafe } from '../../types'
 
 interface CafeFormWizardProps {
@@ -19,7 +20,7 @@ export const CafeFormWizard: React.FC<CafeFormWizardProps> = ({ onSave, onCancel
 
   const [formData, setFormData] = useState({
     name: '',
-    city: 'toronto' as 'toronto' | 'montreal' | 'tokyo',
+    city: 'toronto' as CityKey,
     lat: 0,
     lng: 0,
     address: '',
@@ -258,9 +259,11 @@ export const CafeFormWizard: React.FC<CafeFormWizardProps> = ({ onSave, onCancel
                     required
                     className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
                   >
-                    <option value="toronto">Toronto</option>
-                    <option value="montreal">Montreal</option>
-                    <option value="tokyo">Tokyo</option>
+                    {Object.values(CITIES).map(city => (
+                      <option key={city.key} value={city.key}>
+                        {city.name}
+                      </option>
+                    ))}
                   </select>
                 </div>
 

--- a/frontend/src/stores/cityStore.ts
+++ b/frontend/src/stores/cityStore.ts
@@ -1,8 +1,9 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { api } from '../utils/api'
+import { CityKey } from '../../../shared/types'
 
-export type CityKey = 'toronto' | 'montreal' | 'tokyo' | 'kyoto' | 'osaka' | 'new york' | 'mississauga' | 'scarborough'
+export type { CityKey }
 
 export interface City {
   key: CityKey
@@ -12,6 +13,15 @@ export interface City {
   zoom: number
 }
 
+/**
+ * City configuration for map navigation and display
+ * Keys MUST match VALID_CITY_KEYS in shared/types/index.ts
+ *
+ * To add a new city:
+ * 1. Add the key to VALID_CITY_KEYS in shared/types/index.ts
+ * 2. Add city details here
+ * 3. Deploy and admin UI will automatically include it
+ */
 export const CITIES: Record<CityKey, City> = {
   toronto: {
     key: 'toronto',
@@ -25,27 +35,6 @@ export const CITIES: Record<CityKey, City> = {
     name: 'Montreal',
     shortCode: 'MTL',
     center: [45.5017, -73.5673],
-    zoom: 13,
-  },
-  tokyo: {
-    key: 'tokyo',
-    name: 'Tokyo',
-    shortCode: 'TYO',
-    center: [35.6762, 139.6503],
-    zoom: 13,
-  },
-  kyoto: {
-    key: 'kyoto',
-    name: 'Kyoto',
-    shortCode: 'KYO',
-    center: [35.0116, 135.7681],
-    zoom: 13,
-  },
-  osaka: {
-    key: 'osaka',
-    name: 'Osaka',
-    shortCode: 'OSA',
-    center: [34.6937, 135.5023],
     zoom: 13,
   },
   'new york': {
@@ -67,6 +56,27 @@ export const CITIES: Record<CityKey, City> = {
     name: 'Scarborough',
     shortCode: 'SCA',
     center: [43.7731, -79.2578],
+    zoom: 13,
+  },
+  tokyo: {
+    key: 'tokyo',
+    name: 'Tokyo',
+    shortCode: 'TYO',
+    center: [35.6762, 139.6503],
+    zoom: 13,
+  },
+  kyoto: {
+    key: 'kyoto',
+    name: 'Kyoto',
+    shortCode: 'KYO',
+    center: [35.0116, 135.7681],
+    zoom: 13,
+  },
+  osaka: {
+    key: 'osaka',
+    name: 'Osaka',
+    shortCode: 'OSA',
+    center: [34.6937, 135.5023],
     zoom: 13,
   },
 }
@@ -103,18 +113,10 @@ export const useCityStore = create<CityState>()(
         try {
           const { cities } = await api.cities.getAll()
 
-          // Normalize city names to match CITIES keys
+          // City keys are already normalized in the database
+          // Just need to lowercase and filter to valid CITIES
           const availableCityKeys = cities
-            .map(cityData => {
-              const cityName = cityData.city.toLowerCase().trim()
-
-              // Handle variations (e.g., "new york city" -> "new york")
-              const normalized = cityName
-                .replace(/\s+city$/i, '') // Remove trailing "city"
-                .trim()
-
-              return normalized as CityKey
-            })
+            .map(cityData => cityData.city.toLowerCase().trim() as CityKey)
             .filter(cityKey => cityKey in CITIES)
             // Remove duplicates
             .filter((city, index, self) => self.indexOf(city) === index)

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -80,6 +80,28 @@ export interface CafeWithDistance extends Cafe {
 // CITY TYPES
 // ============================================================================
 
+/**
+ * Valid city keys that can be stored in the database
+ * These must match the keys in the frontend CITIES constant
+ *
+ * To add a new city:
+ * 1. Add the key here
+ * 2. Add city details to frontend/src/stores/cityStore.ts CITIES constant
+ * 3. Deploy and admin UI will automatically include the new city
+ */
+export const VALID_CITY_KEYS = [
+  'toronto',
+  'montreal',
+  'new york',
+  'mississauga',
+  'scarborough',
+  'tokyo',
+  'kyoto',
+  'osaka',
+] as const
+
+export type CityKey = typeof VALID_CITY_KEYS[number]
+
 export interface CityWithCount {
   city: string
   cafe_count: number


### PR DESCRIPTION
### TL;DR

Added a new `/add-city` Claude command and implemented a robust city management system with type safety and validation.

### What changed?

- Created a new `.claude/commands/add-city.md` command to streamline adding new cities
- Added `VALID_CITY_KEYS` constant in shared types as the source of truth for city keys
- Implemented backend validation to ensure city keys match the allowed list
- Added a database migration (`0009_normalize_city_keys.sql`) to normalize existing city data
- Updated the admin UI to dynamically generate city dropdowns from the `CITIES` constant
- Improved the `cityStore.ts` with better typing and documentation
- Created comprehensive documentation in `docs/adding-new-cities.md`
- Fixed CORS configuration in `wrangler.toml` to use consistent localhost port

### How to test?

1. Use the new Claude command: `/add-city vancouver "Vancouver" VAN 49.2827 -123.1207`
2. Verify the command provides the correct code snippets to update
3. After deploying changes, check that:
   - Admin UI shows the new city in dropdown
   - Map city selector includes the new city
   - List view city filter includes the new city
4. Try creating a cafe with an invalid city to verify backend validation

### Why make this change?

This change establishes a bulletproof system for managing cities in MatchaMap that ensures:
- Type safety through TypeScript
- Data integrity with backend validation
- Consistent city keys between frontend and database
- Easy addition of new cities without complex admin UI
- Clear documentation for future developers

The normalized approach prevents issues like inconsistent casing or variations of city names (e.g., "New York" vs "New York City") that could break filtering and display logic.