### PR TITLE
shift filter on map view when card opens

### DIFF
--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -843,7 +843,11 @@ export const MapView: React.FC<MapViewProps> = ({ cafes, showPopover, selectedCa
       )}
 
       {/* Quick Filters - Horizontal Scrollable */}
-      <div className="absolute top-4 left-4 right-4 z-[1003]">
+      <div className={`absolute top-4 right-4 z-[1003] transition-all duration-300 ${
+        showPopover && selectedCafe
+          ? 'left-4 md:left-[22rem] lg:left-[26rem] xl:left-[30rem]' // Shift right on desktop when card is visible
+          : 'left-4'
+      }`}>
         <div className="flex gap-1.5 overflow-x-auto scrollbar-hide pb-1">
           {/* City Selector - Navigation, not filter */}
           <div className="relative flex-shrink-0">


### PR DESCRIPTION
### TL;DR

Improved the quick filters positioning when a cafe card is displayed.

### What changed?

Modified the quick filters container in `MapView.tsx` to dynamically adjust its position based on whether a cafe card is visible. When a cafe card is shown, the filters now shift to the right on desktop screens to avoid overlapping with the card, using responsive positioning with different breakpoints for various screen sizes.

### How to test?

1. Open the map view
2. Verify that quick filters appear normally at the top left
3. Select a cafe to display its card
4. Confirm that on desktop screens, the quick filters shift to the right to avoid overlapping with the cafe card
5. Test on different screen sizes to ensure the responsive positioning works correctly
6. Deselect the cafe and verify the filters return to their original position

### Why make this change?

This change improves the user experience by preventing the quick filters from being obscured by cafe cards on desktop views. The responsive design ensures optimal layout across different screen sizes, maintaining visibility and accessibility of both the filters and cafe information.