### PR TITLE
stop showing long walk times

### DIFF
--- a/frontend/src/components/DetailView.tsx
+++ b/frontend/src/components/DetailView.tsx
@@ -73,7 +73,12 @@ export const DetailView: React.FC<DetailViewProps> = ({ cafe, visitedLocations, 
             {cafe.distanceInfo && (
               <div className="flex items-center gap-2 text-matcha-700 bg-white/60 px-3 py-2 rounded-lg w-fit">
                 <Navigation size={16} className="text-matcha-600" />
-                <span className="text-sm font-semibold">{cafe.distanceInfo.formattedKm} away • {cafe.distanceInfo.walkTime} walk</span>
+                <span className="text-sm font-semibold">
+                  {cafe.distanceInfo.walkTime
+                    ? `${cafe.distanceInfo.formattedKm} away • ${cafe.distanceInfo.walkTime} walk`
+                    : `${cafe.distanceInfo.formattedKm} away`
+                  }
+                </span>
               </div>
             )}
           </div>

--- a/frontend/src/components/ListView.tsx
+++ b/frontend/src/components/ListView.tsx
@@ -639,7 +639,7 @@ export const ListView: React.FC<ListViewProps> = ({ cafes, expandedCard, onToggl
                       {cafe.distanceInfo ? (
                         <span className="flex items-center gap-1 text-matcha-700 font-medium text-xs">
                           <Navigation size={14} className="text-matcha-600" />
-                          {cafe.distanceInfo.kilometers > 5
+                          {cafe.distanceInfo.kilometers > 5 || !cafe.distanceInfo.walkTime
                             ? cafe.distanceInfo.formattedKm
                             : `${cafe.distanceInfo.formattedKm} • ${cafe.distanceInfo.walkTime}`
                           }
@@ -675,7 +675,7 @@ export const ListView: React.FC<ListViewProps> = ({ cafes, expandedCard, onToggl
                   onClick={() => onViewDetails(cafe)}
                   className="flex-1 min-w-[120px] bg-gradient-to-r from-matcha-600 to-matcha-500 text-white py-2.5 px-4 rounded-xl font-semibold hover:from-matcha-700 hover:to-matcha-600 transition-all duration-200 shadow-md hover:shadow-lg active:scale-[0.98] text-sm flex items-center justify-center gap-1.5"
                 >
-                  <span>View Details</span>
+                  <span>{COPY.list.details}</span>
                   <ChevronDown size={14} className="-rotate-90" />
                 </button>
 

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -419,7 +419,12 @@ export const MapView: React.FC<MapViewProps> = ({ cafes, showPopover, selectedCa
             {selectedCafe.distanceInfo ? (
               <div className="flex items-center gap-2 text-sm text-gray-600 mb-2">
                 <Navigation size={16} className="text-green-600" />
-                <span>{selectedCafe.distanceInfo.formattedKm} • {selectedCafe.distanceInfo.walkTime} walk</span>
+                <span>
+                  {selectedCafe.distanceInfo.walkTime
+                    ? `${selectedCafe.distanceInfo.formattedKm} • ${selectedCafe.distanceInfo.walkTime} walk`
+                    : selectedCafe.distanceInfo.formattedKm
+                  }
+                </span>
               </div>
             ) : (
               <button
@@ -604,7 +609,12 @@ export const MapView: React.FC<MapViewProps> = ({ cafes, showPopover, selectedCa
                 {selectedCafe.distanceInfo ? (
                   <div className="flex items-center gap-2 text-gray-600">
                     <Navigation size={18} className="text-green-600" />
-                    <span>{selectedCafe.distanceInfo.formattedKm} • {selectedCafe.distanceInfo.walkTime} walk</span>
+                    <span>
+                      {selectedCafe.distanceInfo.walkTime
+                        ? `${selectedCafe.distanceInfo.formattedKm} • ${selectedCafe.distanceInfo.walkTime} walk`
+                        : selectedCafe.distanceInfo.formattedKm
+                      }
+                    </span>
                   </div>
                 ) : (
                   <button

--- a/frontend/src/constants/copy.ts
+++ b/frontend/src/constants/copy.ts
@@ -115,6 +115,7 @@ export const COPY = {
     clearAll: 'Clear All',
     viewInstagramReview: 'View Instagram review',
     viewTikTokReview: 'View TikTok review',
+    details: 'Details',
   },
 
   // Detail View

--- a/frontend/src/utils/distance.ts
+++ b/frontend/src/utils/distance.ts
@@ -10,7 +10,7 @@ export interface DistanceResult {
   miles: number
   formattedKm: string
   formattedMiles: string
-  walkTime: string
+  walkTime: string | null
 }
 
 /**
@@ -75,8 +75,9 @@ export const formatDistance = (distance: number, unit: 'km' | 'miles'): string =
 /**
  * Calculate estimated walking time based on distance
  * Assumes average walking speed of 5 km/h (3.1 mph)
+ * Returns null for walks over 1 hour
  */
-export const calculateWalkTime = (distanceKm: number): string => {
+export const calculateWalkTime = (distanceKm: number): string | null => {
   const walkingSpeedKmh = 5 // Average walking speed
   const timeHours = distanceKm / walkingSpeedKmh
   const timeMinutes = Math.round(timeHours * 60)
@@ -86,13 +87,8 @@ export const calculateWalkTime = (distanceKm: number): string => {
   } else if (timeMinutes < 60) {
     return `${timeMinutes} min`
   } else {
-    const hours = Math.floor(timeMinutes / 60)
-    const remainingMinutes = timeMinutes % 60
-    if (remainingMinutes === 0) {
-      return `${hours}h`
-    } else {
-      return `${hours}h ${remainingMinutes}m`
-    }
+    // Don't show walk times over an hour
+    return null
   }
 }
 

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -72,7 +72,7 @@ export interface CafeWithDistance extends Cafe {
     miles: number
     formattedKm: string
     formattedMiles: string
-    walkTime: string
+    walkTime: string | null
   } | null
 }
 


### PR DESCRIPTION
### TL;DR

Improved distance display by hiding walk time for longer distances and adding fallback display options when walk time is not available.

### What changed?

- Modified `calculateWalkTime()` to return `null` for walks over 1 hour instead of displaying long walk times
- Updated UI components to handle cases where `walkTime` is null:
  - In `DetailView.tsx`, `ListView.tsx`, and `MapView.tsx`, added conditional rendering to show only distance when walk time is not available
  - In `ListView.tsx`, updated the condition to hide walk time when distance is over 5km OR walk time is null
  - Added a new copy constant `details` in the list section of `copy.ts` and used it in the ListView component

### How to test?

1. View cafes at various distances from your location
2. Verify that cafes within walking distance (under 1 hour walk) show both distance and walk time
3. Verify that cafes far away only show the distance without walk time
4. Check that the UI displays correctly in all views (List, Map, and Detail)

### Why make this change?

Walking directions are only practical for shorter distances. Displaying walk times for locations that would take hours to reach on foot is not useful information and could be misleading to users. This change provides a cleaner, more relevant distance display that focuses on practical information.