### PR TITLE
fix: add overflow-y-auto to admin sidebar for desktop scrolling

### DIFF
--- a/frontend/src/components/admin/AdminLayout.tsx
+++ b/frontend/src/components/admin/AdminLayout.tsx
@@ -117,7 +117,7 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
       {/* Sidebar Navigation - Hidden on mobile unless menu is open */}
       <div className={`${
         mobileMenuOpen ? 'flex' : 'hidden'
-      } md:flex w-full md:w-64 bg-white border-r border-gray-200 shadow-lg flex-col`}>
+      } md:flex w-full md:w-64 bg-white border-r border-gray-200 shadow-lg flex-col overflow-y-auto`}>
         {/* Sidebar Header - Desktop only */}
         <div className="hidden md:block p-6 border-b border-gray-200">
           <div className="flex items-center gap-2 text-green-700">


### PR DESCRIPTION
Fixes #144 - Admin sidebar navigation is now scrollable on desktop when content exceeds viewport height, making all menu items accessible on screens with limited height (800px or less).

Changes:
- Added overflow-y-auto to sidebar container in AdminLayout.tsx:120
- Enables vertical scrolling for Tools & Utilities and Settings sections
- Maintains existing mobile layout functionality

Generated with [Claude Code](https://claude.ai/code)