### PR TITLE
feat: simplify page title to 'MatchaMap' with environment prefixes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,7 +23,7 @@
     integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
     crossorigin=""/>
 
-  <title>MatchaMap - Toronto's Best Matcha Cafes</title>
+  <title>MatchaMap</title>
 </head>
 <body>
   <div id="root"></div>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,25 @@ import App from './App'
 import AdminWrapper from './components/AdminWrapper'
 import './styles/index.css'
 
+// Set dynamic page title based on environment
+const setPageTitle = () => {
+  const isDev = import.meta.env.DEV
+  const isPreview = window.location.hostname.includes('pages.dev') && 
+                    !window.location.hostname.includes('matchamap.pages.dev')
+  
+  let title = 'MatchaMap'
+  
+  if (isDev) {
+    title = '[DEV] MatchaMap'
+  } else if (isPreview) {
+    title = '[PREVIEW] MatchaMap'
+  }
+  
+  document.title = title
+}
+
+setPageTitle()
+
 const rootElement = document.getElementById('root')
 if (!rootElement) throw new Error('Failed to find the root element')
 


### PR DESCRIPTION
Closes #145

Simplifies the browser page title from "MatchaMap - Toronto's Best Matcha Cafes" to just "MatchaMap" with optional environment prefixes for better UX.

## Changes
- Update static title in `index.html` to "MatchaMap"
- Add dynamic title logic in `main.tsx` for environment-based prefixes
- Development: "[DEV] MatchaMap"
- Preview deployments: "[PREVIEW] MatchaMap"
- Production: "MatchaMap"

## Benefits
- ✅ Shorter title fits better in browser tabs
- ✅ Easy to distinguish dev from production environments
- ✅ Meta description preserved for SEO
- ✅ Cleaner, more professional appearance

Generated with [Claude Code](https://claude.ai/code)