### PR TITLE
refactor(feed): prepare newsfeed for social feed foundation

### DIFF
--- a/backend/drizzle/schema.ts
+++ b/backend/drizzle/schema.ts
@@ -64,7 +64,9 @@ export const drinks = sqliteTable('drinks', {
   defaultIdx: index('drinks_default_idx').on(table.isDefault),
 }));
 
-// Feed items table
+// Feed items table (Legacy - Blog/Article Style)
+// NOTE: This table will be replaced by activity_feed in Phase 2
+// See docs/feed-refactoring-plan.md for new schema design
 export const feedItems = sqliteTable('feed_items', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   type: text('type').notNull(), // new_location, score_update, announcement, menu_update, closure

--- a/backend/src/routes/admin-feed.ts
+++ b/backend/src/routes/admin-feed.ts
@@ -1,3 +1,13 @@
+/**
+ * Legacy Feed Management Routes (Deprecated)
+ * 
+ * NOTE: This is the old blog/article-style feed system.
+ * In Phase 2, this will be replaced by auto-generated activity feed
+ * from user actions (check-ins, reviews, photos).
+ * 
+ * Current status: Functional but deprecated
+ * Migration plan: See docs/feed-refactoring-plan.md
+ */
 import { IRequest } from 'itty-router';
 import { eq, desc, and } from 'drizzle-orm';
 import { Env } from '../types';

--- a/backend/src/routes/feed.ts
+++ b/backend/src/routes/feed.ts
@@ -1,3 +1,13 @@
+/**
+ * Legacy Public Feed API (Deprecated)
+ * 
+ * NOTE: This serves the old blog/article-style feed items.
+ * In Phase 2, this will be replaced by activity feed endpoints
+ * serving user-generated content (check-ins, reviews, photos).
+ * 
+ * Current status: Functional but deprecated
+ * Migration plan: See docs/feed-refactoring-plan.md
+ */
 import { IRequest } from 'itty-router';
 import { eq, and, desc } from 'drizzle-orm';
 import { Env } from '../types';

--- a/docs/feed-refactoring-plan.md
+++ b/docs/feed-refactoring-plan.md
@@ -1,0 +1,154 @@
+# Feed Refactoring Plan
+
+## Current State (Phase 1)
+
+The feed system was originally designed for admin-curated blog posts:
+- **Table:** `feed_items`
+- **Purpose:** Announcements, new locations, score updates
+- **Content type:** Long-form articles with preview/content
+- **Admin CRUD interface** with complex form
+
+## Target State (Phase 2)
+
+The feed will become a social activity stream:
+- **Table:** `activity_feed` (new)
+- **Purpose:** User-generated content aggregation
+- **Content type:** Activity items (check-ins, reviews, photos)
+- **Auto-generated** from user actions (no admin CRUD)
+
+## Migration Steps
+
+### 1. ✅ Phase 1 Cleanup (This Issue)
+   - [x] Simplify/deprecate admin feed UI
+   - [x] Update terminology (newsfeed → feed/activity feed)
+   - [x] Add code markers for legacy components
+   - [x] Update copy constants
+   - [x] Add deprecation warnings in admin UI
+   - [x] Mark backend routes as deprecated
+   - [x] Add database schema comments
+
+### 2. ⏳ Phase 2A: New Activity Feed Table
+   - Create `activity_feed` table with new schema
+   - Add activity generation triggers for user actions
+   - Build feed aggregation queries with following system
+   - Create new API endpoints for activity feed
+
+### 3. ⏳ Phase 2B: Frontend Activity Feed
+   - New `ActivityFeed.tsx` component
+   - Following-based filtering
+   - Real-time updates (WebSocket/SSE)
+   - Activity type components (check-in, review, photo)
+
+### 4. ⏳ Phase 2C: Migration & Cleanup
+   - Migrate any useful feed_items to activity format
+   - Remove old feed_items table
+   - Remove admin feed CRUD interface
+   - Remove legacy endpoints (`/api/feed`, `/api/admin/feed`)
+
+## New Activity Feed Schema (Phase 2)
+
+```sql
+CREATE TABLE activity_feed (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  activity_type TEXT NOT NULL, -- 'check_in', 'review', 'photo', 'badge_earned'
+  
+  -- Content
+  content TEXT, -- Optional text content
+  
+  -- Relations
+  cafe_id INTEGER REFERENCES cafes(id),
+  review_id INTEGER REFERENCES reviews(id),
+  photo_id INTEGER REFERENCES photos(id),
+  
+  -- Metadata
+  visibility TEXT DEFAULT 'public', -- 'public', 'followers', 'private'
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  
+  -- Indexes
+  INDEX activity_feed_user_idx (user_id),
+  INDEX activity_feed_cafe_idx (cafe_id),
+  INDEX activity_feed_type_idx (activity_type),
+  INDEX activity_feed_created_idx (created_at)
+);
+```
+
+## Activity Types
+
+1. **Check-ins:** `"@username checked in at Café Name"`
+2. **Reviews:** `"@username reviewed Café Name (8.5/10)"`
+3. **Photos:** `"@username posted a photo at Café Name"`
+4. **Badges:** `"@username earned the 'Matcha Explorer' badge"`
+5. **Follow:** `"@username started following @othername"`
+
+## Breaking Changes
+
+- `feed_items` table will be dropped
+- Admin feed CRUD endpoints will be removed
+- Feed item types will change format
+- New activity schema (see above)
+
+## Legacy Code Markers
+
+Throughout the codebase, legacy feed code is marked with:
+
+```typescript
+// TODO(Phase 2): Replace with activity_feed system
+// See: docs/feed-refactoring-plan.md
+```
+
+This makes it easy to find all feed-related code when implementing Phase 2.
+
+## Files Affected by Refactoring
+
+### Phase 1 Changes (Completed)
+- ✅ `frontend/src/constants/copy.ts` - Updated feed copy
+- ✅ `frontend/src/components/admin/AdminLayout.tsx` - Renamed nav item
+- ✅ `frontend/src/components/admin/NewsfeedManagementPage.tsx` - Added deprecation notice
+- ✅ `backend/src/routes/admin-feed.ts` - Added deprecation header
+- ✅ `backend/src/routes/feed.ts` - Added deprecation header
+- ✅ `backend/drizzle/schema.ts` - Added table deprecation comment
+- ✅ `frontend/src/utils/api.ts` - Added API deprecation comment
+
+### Phase 2 Changes (Future)
+- ⏳ `backend/drizzle/schema.ts` - Add activity_feed table
+- ⏳ `backend/src/routes/activity-feed.ts` - New activity endpoints
+- ⏳ `frontend/src/components/ActivityFeed.tsx` - New activity feed component
+- ⏳ `frontend/src/utils/api.ts` - New activity API methods
+- ⏳ Remove all legacy feed files
+
+## Testing Strategy
+
+### Phase 1 (Current)
+- [x] Admin UI shows deprecation warnings
+- [x] Legacy functionality still works
+- [x] TypeScript compiles without errors
+- [x] No breaking changes for existing users
+
+### Phase 2 (Future)
+- Activity feed API tests
+- Activity generation tests
+- Following system tests
+- Real-time update tests
+
+## Success Criteria
+
+### Phase 1 ✅
+- [x] Admin feed interface shows deprecation warnings
+- [x] Code clearly marked as legacy/Phase 1
+- [x] Documentation explains refactoring plan
+- [x] No broken functionality
+- [x] Easy to identify what needs replacement in Phase 2
+
+### Phase 2 (Future Goals)
+- [ ] Activity feed generates from user actions
+- [ ] Following system filters activity
+- [ ] Real-time updates work
+- [ ] Legacy feed system completely removed
+- [ ] Performance is better than legacy system
+
+## Related Documentation
+
+- `docs/social-features-guide.md` - Full social features spec
+- `docs/TECH_SPEC.md` - Database schema reference
+- Phase 2D section: Activity Feed implementation plan

--- a/frontend/src/components/admin/AdminLayout.tsx
+++ b/frontend/src/components/admin/AdminLayout.tsx
@@ -29,7 +29,7 @@ const coreNavItems: NavItem[] = [
   },
   {
     id: 'newsfeed',
-    label: 'Newsfeed',
+    label: 'Feed (Legacy)',
     icon: <Newspaper size={20} />,
     path: '/admin/newsfeed',
   },

--- a/frontend/src/components/admin/NewsfeedManagementPage.tsx
+++ b/frontend/src/components/admin/NewsfeedManagementPage.tsx
@@ -3,6 +3,16 @@ import { Newspaper, Plus, Search, Edit, Trash2, Eye, EyeOff } from 'lucide-react
 import { api } from '../../utils/api'
 import type { FeedItem } from '../../../../shared/types'
 
+/**
+ * Legacy Feed Management Page (Deprecated)
+ * 
+ * NOTE: This is the old blog/article-style feed system.
+ * In Phase 2, this will be replaced by auto-generated activity feed
+ * from user actions (check-ins, reviews, photos).
+ * 
+ * Current status: Functional but deprecated
+ * Migration plan: See docs/feed-refactoring-plan.md
+ */
 export const NewsfeedManagementPage: React.FC = () => {
   const [feedItems, setFeedItems] = useState<FeedItem[]>([])
   const [loading, setLoading] = useState(true)
@@ -246,10 +256,13 @@ export const NewsfeedManagementPage: React.FC = () => {
             <div>
               <h1 className="text-xl md:text-2xl font-bold text-green-800 mb-2 flex items-center gap-2">
                 <Newspaper size={28} />
-                Newsfeed Management
+                Feed Management (Legacy)
               </h1>
               <p className="text-sm md:text-base text-gray-600">
-                Manage news updates, announcements, and blog posts
+                ⚠️ <strong>Deprecated:</strong> This will be replaced by auto-generated activity feed in Phase 2
+              </p>
+              <p className="text-xs text-gray-500 mt-1">
+                See docs/feed-refactoring-plan.md for migration details
               </p>
             </div>
 

--- a/frontend/src/constants/copy.ts
+++ b/frontend/src/constants/copy.ts
@@ -167,9 +167,12 @@ export const COPY = {
 
   // Feed View
   feed: {
-    title: 'Feed',
+    title: 'Activity Feed',
+    subtitle: 'See what the community is up to',
+    noActivity: 'No recent activity',
+    checkBackSoon: 'Check back soon for updates from the community!',
+    // Legacy blog/article strings (deprecated - will be removed in Phase 2)
     noUpdates: 'No updates yet',
-    checkBackSoon: 'Check back soon for matcha news and updates!',
   },
 
   // Events View
@@ -353,7 +356,8 @@ export const COPY = {
     cafes: 'Cafes',
     drinks: 'Drinks',
     events: 'Events',
-    feed: 'News Feed',
+    feed: 'Feed (Legacy)', // Mark as legacy for Phase 2 replacement
+    newsfeed: 'Feed Management (Deprecated)', // Add deprecation note
     stats: 'Analytics',
     users: 'Users',
     settings: 'Settings',

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -151,7 +151,10 @@ export const cafeAPI = {
 }
 
 /**
- * Feed API endpoints
+ * Feed API endpoints (Legacy - Deprecated)
+ * 
+ * TODO(Phase 2): Replace with activity_feed system
+ * See: docs/feed-refactoring-plan.md
  */
 export const feedAPI = {
   /**


### PR DESCRIPTION
Refactors the existing newsfeed feature to prepare for Phase 2 social activity feed implementation.

## Changes

- ✅ Updated copy constants: 'Newsfeed' → 'Activity Feed' with social-focused text
- ✅ Added deprecation notices in admin UI with migration guidance
- ✅ Marked backend routes and database schema as legacy/deprecated
- ✅ Created comprehensive feed refactoring plan documentation
- ✅ Maintained all existing functionality while preparing for Phase 2

## Migration Plan

See `docs/feed-refactoring-plan.md` for the complete Phase 2 migration strategy.

Closes #149

Generated with [Claude Code](https://claude.ai/code)