### PR TITLE
feat(backend): add user reviews database schema and types (Phase 2A)

### DIFF
--- a/backend/drizzle/migrations/0012_add_user_reviews_tables.sql
+++ b/backend/drizzle/migrations/0012_add_user_reviews_tables.sql
@@ -16,10 +16,10 @@ CREATE TABLE `user_reviews` (
 	`title` text,
 	`content` text NOT NULL CHECK(LENGTH(`content`) >= 50 AND LENGTH(`content`) <= 2000),
 	`tags` text,
-	`visit_date` text,
+	`visit_date` text CHECK(`visit_date` IS NULL OR date(`visit_date`) <= date('now')),
 	`is_public` integer DEFAULT 1,
 	`is_featured` integer DEFAULT 0,
-	`moderation_status` text DEFAULT 'approved' CHECK(`moderation_status` IN ('pending', 'approved', 'rejected', 'flagged')),
+	`moderation_status` text DEFAULT 'pending' CHECK(`moderation_status` IN ('pending', 'approved', 'rejected', 'flagged')),
 	`moderation_notes` text,
 	`moderated_by` integer,
 	`moderated_at` text,
@@ -45,9 +45,9 @@ CREATE TABLE `review_photos` (
 	`thumbnail_url` text,
 	`caption` text,
 	`drink_type` text,
-	`width` integer,
-	`height` integer,
-	`file_size` integer,
+	`width` integer CHECK(`width` IS NULL OR (`width` > 0 AND `width` <= 4096)),
+	`height` integer CHECK(`height` IS NULL OR (`height` > 0 AND `height` <= 4096)),
+	`file_size` integer CHECK(`file_size` IS NULL OR (`file_size` > 0 AND `file_size` <= 10485760)),
 	`moderation_status` text DEFAULT 'pending' CHECK(`moderation_status` IN ('pending', 'approved', 'rejected')),
 	`moderated_by` integer,
 	`moderated_at` text,
@@ -78,6 +78,8 @@ CREATE INDEX `idx_user_reviews_cafe` ON `user_reviews` (`cafe_id`);--> statement
 CREATE INDEX `idx_user_reviews_rating` ON `user_reviews` (`overall_rating` DESC);--> statement-breakpoint
 CREATE INDEX `idx_user_reviews_created` ON `user_reviews` (`created_at` DESC);--> statement-breakpoint
 CREATE INDEX `idx_user_reviews_status` ON `user_reviews` (`moderation_status`);--> statement-breakpoint
+CREATE INDEX `idx_user_reviews_cafe_rating` ON `user_reviews` (`cafe_id`, `overall_rating` DESC);--> statement-breakpoint
+CREATE INDEX `idx_user_reviews_status_created` ON `user_reviews` (`moderation_status`, `created_at` DESC);--> statement-breakpoint
 
 CREATE INDEX `idx_review_photos_review` ON `review_photos` (`review_id`);--> statement-breakpoint
 CREATE INDEX `idx_review_photos_cafe` ON `review_photos` (`cafe_id`);--> statement-breakpoint

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -298,6 +298,25 @@ export interface UserBadge {
 // USER REVIEW TYPES (Phase 2A)
 // ============================================================================
 
+// Review moderation status constants
+export const REVIEW_MODERATION_STATUS = {
+  PENDING: 'pending',
+  APPROVED: 'approved',
+  REJECTED: 'rejected',
+  FLAGGED: 'flagged'
+} as const
+
+export type ReviewModerationStatus = typeof REVIEW_MODERATION_STATUS[keyof typeof REVIEW_MODERATION_STATUS]
+
+// Photo moderation status constants (subset of review statuses)
+export const PHOTO_MODERATION_STATUS = {
+  PENDING: 'pending',
+  APPROVED: 'approved',
+  REJECTED: 'rejected'
+} as const
+
+export type PhotoModerationStatus = typeof PHOTO_MODERATION_STATUS[keyof typeof PHOTO_MODERATION_STATUS]
+
 export interface UserReview {
   id: number
   userId: number
@@ -321,7 +340,7 @@ export interface UserReview {
   isFeatured: boolean
   
   // Moderation
-  moderationStatus: 'pending' | 'approved' | 'rejected' | 'flagged'
+  moderationStatus: ReviewModerationStatus
   moderationNotes?: string
   moderatedBy?: number
   moderatedAt?: string
@@ -358,7 +377,7 @@ export interface ReviewPhoto {
   fileSize?: number
   
   // Moderation
-  moderationStatus: 'pending' | 'approved' | 'rejected'
+  moderationStatus: PhotoModerationStatus
   moderatedBy?: number
   moderatedAt?: string
   


### PR DESCRIPTION
Add comprehensive user reviews database schema and TypeScript types for Phase 2A foundation.

## Changes
- Create user_reviews table with rating fields, content, and moderation
- Create review_photos table for R2 storage integration
- Create review_helpful table for helpful vote tracking
- Add performance indexes for user_id, cafe_id, rating, created_at
- Add TypeScript interfaces: UserReview, ReviewPhoto, ReviewHelpful
- Enforce CHECK constraints for rating validation (0-10 scale)
- Add UNIQUE constraint preventing duplicate reviews per user/cafe
- Support CASCADE deletes for data integrity

Closes #167

Generated with [Claude Code](https://claude.ai/code)