### PR TITLE
new labels

### DIFF
--- a/.github/FIX_LABELS.md
+++ b/.github/FIX_LABELS.md
@@ -1,0 +1,97 @@
+# Fix Labels - Auto-removal System
+
+## Available Labels
+
+These labels help track quality issues in PRs and are **automatically removed** when the corresponding checks pass:
+
+| Label | Description | Removed When |
+|-------|-------------|--------------|
+| `fix-tests` | Tests are failing | Frontend Tests AND Backend Tests jobs pass |
+| `fix-typecheck` | TypeScript type errors | Static Analysis job passes (includes typecheck) |
+| `fix-build` | Build is failing | Build job passes |
+| `fix-lint` | Linting errors | Static Analysis job passes (includes lint) |
+
+## How It Works
+
+1. **Manual Labeling**: Add these labels to PRs when you identify issues
+2. **Automatic Removal**: The `auto-remove-fix-labels.yml` workflow runs after CI completes
+3. **Smart Detection**: Labels are only removed when all required checks pass
+
+## Usage Examples
+
+### Scenario 1: PR with test failures
+```bash
+# Add label manually or via gh CLI
+gh pr edit 123 --add-label "fix-tests"
+
+# After tests are fixed and CI passes, label is auto-removed
+```
+
+### Scenario 2: Multiple issues
+```bash
+# Add multiple labels
+gh pr edit 123 --add-label "fix-tests,fix-typecheck,fix-lint"
+
+# As each check passes, corresponding labels are removed
+# - Static Analysis passes → removes fix-typecheck and fix-lint
+# - Tests pass → removes fix-tests
+```
+
+## Workflow Details
+
+**Trigger**: Runs after the CI workflow completes on PRs
+
+**Steps**:
+1. Identifies the PR associated with the workflow run
+2. Checks results of all CI jobs
+3. Compares current PR labels with job results
+4. Removes labels for passing checks
+
+**Requirements**:
+- PR must be open
+- CI workflow must complete (success or failure)
+- Labels must exist on the PR for removal to occur
+
+## CI Job Mapping
+
+The workflow maps labels to these CI jobs:
+
+```yaml
+fix-tests:
+  - Frontend Tests
+  - Backend Tests
+
+fix-typecheck:
+  - Static Analysis (typecheck step)
+
+fix-build:
+  - Build
+
+fix-lint:
+  - Static Analysis (lint step)
+```
+
+## Tips
+
+- Use these labels for tracking issues across PRs
+- Labels are visual indicators of what needs attention
+- Automation ensures labels stay accurate as issues are resolved
+- Can be combined with GitHub Projects for better tracking
+
+## Debugging
+
+To check if the workflow is running correctly:
+
+```bash
+# View workflow runs
+gh run list --workflow=auto-remove-fix-labels.yml
+
+# View specific run logs
+gh run view <run-id> --log
+```
+
+## Configuration
+
+The workflow file: `.github/workflows/auto-remove-fix-labels.yml`
+
+To modify label rules, edit the `labelRules` object in the workflow script.

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,200 @@
+name: Auto Merge
+
+on:
+  # Trigger when PR is labeled
+  pull_request:
+    types: [labeled]
+
+  # Trigger when checks complete
+  check_suite:
+    types: [completed]
+
+  # Trigger when PR is approved
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  auto-merge:
+    name: Auto Merge PR
+    runs-on: ubuntu-latest
+
+    # Only run on PRs with auto-merge label
+    if: |
+      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'auto-merge') ||
+      github.event_name == 'pull_request_review' && contains(github.event.pull_request.labels.*.name, 'auto-merge') ||
+      github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success'
+
+    steps:
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Find the PR associated with this event
+            let pr;
+
+            if (context.eventName === 'pull_request' || context.eventName === 'pull_request_review') {
+              pr = context.payload.pull_request;
+            } else if (context.eventName === 'check_suite') {
+              // Find PRs associated with this check suite
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                head: `${context.repo.owner}:${context.payload.check_suite.head_branch}`
+              });
+
+              if (prs.length === 0) {
+                core.info('No open PRs found for this check suite');
+                return;
+              }
+
+              pr = prs[0];
+            }
+
+            if (!pr) {
+              core.info('No PR found');
+              return;
+            }
+
+            // Check if PR has auto-merge label
+            const hasAutoMergeLabel = pr.labels.some(label => label.name === 'auto-merge');
+
+            if (!hasAutoMergeLabel) {
+              core.info(`PR #${pr.number} does not have auto-merge label`);
+              return;
+            }
+
+            core.setOutput('number', pr.number);
+            core.setOutput('sha', pr.head.sha);
+            return pr.number;
+
+      - name: Check PR approval status
+        id: approval
+        if: steps.pr.outputs.number
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+
+            // Get reviews for the PR
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            // Check if PR has at least one approval
+            const hasApproval = reviews.some(review => review.state === 'APPROVED');
+
+            if (!hasApproval) {
+              core.info(`PR #${prNumber} is not approved yet`);
+              core.setOutput('approved', 'false');
+              return false;
+            }
+
+            // Check for any pending change requests
+            const latestReviews = {};
+            for (const review of reviews) {
+              if (!latestReviews[review.user.id] || new Date(review.submitted_at) > new Date(latestReviews[review.user.id].submitted_at)) {
+                latestReviews[review.user.id] = review;
+              }
+            }
+
+            const hasChangeRequest = Object.values(latestReviews).some(review => review.state === 'CHANGES_REQUESTED');
+
+            if (hasChangeRequest) {
+              core.info(`PR #${prNumber} has pending change requests`);
+              core.setOutput('approved', 'false');
+              return false;
+            }
+
+            core.info(`PR #${prNumber} is approved and has no change requests`);
+            core.setOutput('approved', 'true');
+            return true;
+
+      - name: Check CI status
+        id: ci
+        if: steps.pr.outputs.number && steps.approval.outputs.approved == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+            const sha = '${{ steps.pr.outputs.sha }}';
+
+            // Get check runs for the PR
+            const { data: checkRuns } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha
+            });
+
+            // Get status checks for the PR
+            const { data: statuses } = await github.rest.repos.getCombinedStatusForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha
+            });
+
+            // Required check names (based on your ci.yml workflow)
+            const requiredChecks = [
+              'Static Analysis',
+              'Frontend Tests',
+              'Build',
+              'CI Success'
+            ];
+
+            // Check if all required checks passed
+            const allChecksPassed = requiredChecks.every(checkName => {
+              const checkRun = checkRuns.check_runs.find(run => run.name === checkName);
+              return checkRun && checkRun.conclusion === 'success';
+            });
+
+            if (!allChecksPassed) {
+              core.info(`PR #${prNumber} has pending or failing CI checks`);
+              core.setOutput('passed', 'false');
+              return false;
+            }
+
+            // Also check combined status (for other integrations)
+            if (statuses.state !== 'success' && statuses.total_count > 0) {
+              core.info(`PR #${prNumber} has failing status checks`);
+              core.setOutput('passed', 'false');
+              return false;
+            }
+
+            core.info(`PR #${prNumber} has all required checks passing`);
+            core.setOutput('passed', 'true');
+            return true;
+
+      - name: Merge PR
+        if: |
+          steps.pr.outputs.number &&
+          steps.approval.outputs.approved == 'true' &&
+          steps.ci.outputs.passed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+
+            try {
+              await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                merge_method: 'squash', // Options: 'merge', 'squash', 'rebase'
+                commit_title: `Auto-merge PR #${prNumber}`,
+              });
+
+              core.info(`✅ Successfully merged PR #${prNumber}`);
+
+              // Add a comment to the PR
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: '✅ Auto-merged after all checks passed and approval was received.'
+              });
+            } catch (error) {
+              core.setFailed(`Failed to merge PR: ${error.message}`);
+            }

--- a/.github/workflows/auto-remove-fix-labels.yml
+++ b/.github/workflows/auto-remove-fix-labels.yml
@@ -1,0 +1,125 @@
+name: Auto-remove Fix Labels
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  remove-labels:
+    name: Remove Fix Labels
+    runs-on: self-hosted
+    if: github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      - name: Get PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pulls = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${context.payload.workflow_run.head_branch}`,
+              state: 'open'
+            });
+
+            if (pulls.data.length === 0) {
+              console.log('No open PR found for this branch');
+              return null;
+            }
+
+            const prNumber = pulls.data[0].number;
+            console.log(`Found PR #${prNumber}`);
+            return prNumber;
+
+      - name: Get workflow jobs
+        id: jobs
+        if: steps.pr.outputs.result != 'null'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id
+            });
+
+            // Map job names to results
+            const jobResults = {};
+            for (const job of jobs.data.jobs) {
+              jobResults[job.name] = job.conclusion;
+            }
+
+            console.log('Job results:', JSON.stringify(jobResults, null, 2));
+            return jobResults;
+
+      - name: Remove labels based on passing checks
+        if: steps.pr.outputs.result != 'null'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.result }};
+            const jobResults = ${{ steps.jobs.outputs.result }};
+
+            // Get current labels on the PR
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const currentLabelNames = currentLabels.map(l => l.name);
+            console.log('Current labels:', currentLabelNames);
+
+            // Define label removal rules based on job results
+            const labelRules = {
+              'fix-tests': ['Frontend Tests', 'Backend Tests'],
+              'fix-typecheck': ['Static Analysis'],  // typecheck is part of static-analysis
+              'fix-build': ['Build'],
+              'fix-lint': ['Static Analysis']  // lint is part of static-analysis
+            };
+
+            // Check which labels should be removed
+            const labelsToRemove = [];
+
+            for (const [label, requiredJobs] of Object.entries(labelRules)) {
+              // Check if the label is currently on the PR
+              if (!currentLabelNames.includes(label)) {
+                continue;
+              }
+
+              // Check if all required jobs passed
+              const allJobsPassed = requiredJobs.every(jobName => {
+                return jobResults[jobName] === 'success';
+              });
+
+              if (allJobsPassed) {
+                labelsToRemove.push(label);
+                console.log(`✅ ${label}: All required jobs passed, will remove label`);
+              } else {
+                console.log(`⏭️ ${label}: Not all required jobs passed yet`);
+              }
+            }
+
+            // Remove labels
+            for (const label of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: label
+                });
+                console.log(`✅ Removed label: ${label}`);
+              } catch (error) {
+                console.log(`ℹ️ Could not remove label ${label}:`, error.message);
+              }
+            }
+
+            if (labelsToRemove.length === 0) {
+              console.log('ℹ️ No labels to remove');
+            } else {
+              console.log(`✅ Removed ${labelsToRemove.length} label(s): ${labelsToRemove.join(', ')}`);
+            }


### PR DESCRIPTION
# Auto-merge and Fix Labels Automation

### TL;DR

Added GitHub Actions workflows for auto-merging PRs and automatically removing "fix-*" labels when CI checks pass.

### What changed?

- Added `.github/FIX_LABELS.md` documentation explaining the fix labels system
- Created `auto-remove-fix-labels.yml` workflow that removes fix labels when corresponding checks pass
- Created `auto-merge.yml` workflow that automatically merges PRs with the `auto-merge` label when:
  - PR has at least one approval
  - No pending change requests
  - All required CI checks pass

### How to test?

For fix labels:
1. Add a label like `fix-tests` to a PR with failing tests
2. Fix the tests and push the changes
3. Verify the label is automatically removed when tests pass

For auto-merge:
1. Add the `auto-merge` label to a PR
2. Get an approval on the PR
3. Ensure all CI checks pass
4. Verify the PR is automatically merged with a confirmation comment

### Why make this change?

These automations improve developer workflow by:
- Providing visual indicators of what needs fixing in PRs
- Automatically cleaning up labels when issues are resolved
- Reducing manual work for merging simple, approved PRs
- Ensuring PRs are only merged when they meet quality standards