### PR TITLE
feat(auth): allow admin users to bypass cover page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,7 @@ const SESSION_KEY = 'matchamap_unlocked'
 
 export const App: React.FC = () => {
   const { showComingSoon } = useAppFeatures()
-  const { getCurrentUser } = useAuthStore()
+  const { getCurrentUser, user, isAuthenticated } = useAuthStore()
   const [hasEnteredPassword, setHasEnteredPassword] = useState(() => {
     // Check sessionStorage on mount
     return sessionStorage.getItem(SESSION_KEY) === 'true'
@@ -30,7 +30,10 @@ export const App: React.FC = () => {
     setHasEnteredPassword(true)
   }
 
-  if (showComingSoon && !hasEnteredPassword) {
+  // Admin users bypass cover page
+  const isAdmin = isAuthenticated && user?.role === 'admin'
+  
+  if (showComingSoon && !hasEnteredPassword && !isAdmin) {
     return <ComingSoon onPasswordCorrect={handlePasswordCorrect} />
   }
 


### PR DESCRIPTION
## Summary

Allow admin users to bypass the coming soon cover page when logged in, improving admin workflow during the pre-launch period.

## Changes
- Add admin bypass logic to App.tsx cover page check
- Extract user and isAuthenticated from authStore
- Check if user is authenticated admin before showing cover page
- Maintains existing password protection for non-admin users

## Test Plan
- Admin login flow: Navigate to `/admin`, log in, should bypass cover page
- Regular user flow: Navigate to `/`, should still see cover page
- Password entry: Should work for non-authenticated users
- Admin logout: Should show cover page again after logout

Fixes #260

Generated with [Claude Code](https://claude.ai/code)