### PR TITLE
fix: update CSP to allow Cloudflare Insights beacon script

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com https://unpkg.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://cdnjs.cloudflare.com https://unpkg.com https://*.cartocdn.com; connect-src 'self' https://api.matchamap.club https://matchamap-api-production.kevingeng33.workers.dev https://*.openrouteservice.org; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com https://unpkg.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://cdnjs.cloudflare.com https://unpkg.com https://*.cartocdn.com; connect-src 'self' https://api.matchamap.club https://matchamap-api-production.kevingeng33.workers.dev https://*.openrouteservice.org https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin


### PR DESCRIPTION
Fixes Content Security Policy violation for Cloudflare Insights beacon script in production.

## Changes
- Add `https://static.cloudflareinsights.com` to `script-src` for beacon.min.js
- Add `https://cloudflareinsights.com` to `connect-src` for analytics data

## Testing
- Deploy to production and verify no CSP violation errors in browser console
- Confirm Cloudflare Analytics continues to collect data

Closes #272

Generated with [Claude Code](https://claude.ai/code)