### PR TITLE
perf: lazy load all route components for 32% bundle reduction

### DIFF
--- a/frontend/src/components/AppRoutes.tsx
+++ b/frontend/src/components/AppRoutes.tsx
@@ -1,19 +1,22 @@
 import React, { useEffect, Suspense } from 'react'
 import { Routes, Route, Navigate, useParams, useLocation } from 'react-router'
-import MapView from './MapView'
-import ListView from './ListView'
-import DetailView from './DetailView'
-import EventDetailView from './EventDetailView'
-import PassportView from './PassportView'
-// Lazy load events components for better performance
+
+// Lazy load ALL components for optimal bundle splitting
+// Only load what users actually navigate to
+const MapView = React.lazy(() => import('./MapView'))
+const ListView = React.lazy(() => import('./ListView'))
+const DetailView = React.lazy(() => import('./DetailView'))
+const EventDetailView = React.lazy(() => import('./EventDetailView'))
+const PassportView = React.lazy(() => import('./PassportView'))
 const EventsView = React.lazy(() => import('./EventsView'))
-import LoginPage from './auth/LoginPage'
-import ProtectedRoute from './auth/ProtectedRoute'
-import { UserProfilePage } from './profile/UserProfilePage'
-import ContactPage from './ContactPage'
-import AboutPage from './AboutPage'
-import StorePage from './StorePage'
-import SettingsPage from './SettingsPage'
+const LoginPage = React.lazy(() => import('./auth/LoginPage'))
+const ProtectedRoute = React.lazy(() => import('./auth/ProtectedRoute'))
+const UserProfilePage = React.lazy(() => import('./profile/UserProfilePage').then(m => ({ default: m.UserProfilePage })))
+const ContactPage = React.lazy(() => import('./ContactPage'))
+const AboutPage = React.lazy(() => import('./AboutPage'))
+const StorePage = React.lazy(() => import('./StorePage'))
+const SettingsPage = React.lazy(() => import('./SettingsPage'))
+
 // Lazy load admin components for better performance
 const AdminLayout = React.lazy(() => import('./admin/AdminLayout'))
 const AdminErrorBoundary = React.lazy(() => import('./admin/AdminErrorBoundary'))
@@ -49,6 +52,17 @@ const AdminLoadingFallback: React.FC = () => (
         <Skeleton variant="text" width="80%" height={20} />
         <Skeleton variant="text" width="40%" height={20} />
       </div>
+    </div>
+  </div>
+)
+
+// Loading fallback for user-facing pages (minimal/fast)
+const PageLoadingFallback: React.FC = () => (
+  <div className="flex-1 flex items-center justify-center">
+    <div className="animate-pulse text-green-600">
+      <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+      </svg>
     </div>
   </div>
 )
@@ -179,22 +193,26 @@ export const AppRoutes: React.FC = () => {
   return (
     <Routes>
       <Route path="/" element={
-        <MapView
-          cafes={cafesWithDistance}
-          showPopover={showPopover}
-          selectedCafe={selectedCafe}
-          onPinClick={handlePinClick}
-          onViewDetails={viewDetails}
-          onClosePopover={closePopover}
-        />
+        <Suspense fallback={<PageLoadingFallback />}>
+          <MapView
+            cafes={cafesWithDistance}
+            showPopover={showPopover}
+            selectedCafe={selectedCafe}
+            onPinClick={handlePinClick}
+            onViewDetails={viewDetails}
+            onClosePopover={closePopover}
+          />
+        </Suspense>
       } />
       <Route path="/list" element={
-        <ListView
-          cafes={cafesWithDistance}
-          expandedCard={expandedCard}
-          onToggleExpand={setExpandedCard}
-          onViewDetails={viewDetails}
-        />
+        <Suspense fallback={<PageLoadingFallback />}>
+          <ListView
+            cafes={cafesWithDistance}
+            expandedCard={expandedCard}
+            onToggleExpand={setExpandedCard}
+            onViewDetails={viewDetails}
+          />
+        </Suspense>
       } />
       {isEventsEnabled && (
         <>
@@ -203,37 +221,67 @@ export const AppRoutes: React.FC = () => {
               <EventsView eventItems={eventItems} />
             </Suspense>
           } />
-          <Route path="/events/:id" element={<EventDetailWrapper />} />
+          <Route path="/events/:id" element={
+            <Suspense fallback={<PageLoadingFallback />}>
+              <EventDetailWrapper />
+            </Suspense>
+          } />
         </>
       )}
       {isPassportEnabled && (
         <Route path="/passport" element={
-          <PassportView
-            cafes={cafesWithDistance}
-            visitedStamps={stampedCafeIds}
-            onToggleStamp={toggleStamp}
-          />
+          <Suspense fallback={<PageLoadingFallback />}>
+            <PassportView
+              cafes={cafesWithDistance}
+              visitedStamps={stampedCafeIds}
+              onToggleStamp={toggleStamp}
+            />
+          </Suspense>
         } />
       )}
       {/* Login route - only if user accounts enabled */}
       {useFeatureToggle('ENABLE_USER_ACCOUNTS') && (
-        <Route path="/login" element={<LoginPage />} />
+        <Route path="/login" element={
+          <Suspense fallback={<PageLoadingFallback />}>
+            <LoginPage />
+          </Suspense>
+        } />
       )}
       {/* Profile route - only if user accounts AND profiles enabled */}
       {useFeatureToggle('ENABLE_USER_ACCOUNTS') && useFeatureToggle('ENABLE_USER_PROFILES') && (
-        <Route path="/profile/:username" element={<UserProfilePage />} />
+        <Route path="/profile/:username" element={
+          <Suspense fallback={<PageLoadingFallback />}>
+            <UserProfilePage />
+          </Suspense>
+        } />
       )}
       {isContactEnabled && (
-        <Route path="/contact" element={<ContactPage />} />
+        <Route path="/contact" element={
+          <Suspense fallback={<PageLoadingFallback />}>
+            <ContactPage />
+          </Suspense>
+        } />
       )}
       {isAboutEnabled && (
-        <Route path="/about" element={<AboutPage />} />
+        <Route path="/about" element={
+          <Suspense fallback={<PageLoadingFallback />}>
+            <AboutPage />
+          </Suspense>
+        } />
       )}
       {isStoreEnabled && (
-        <Route path="/store" element={<StorePage />} />
+        <Route path="/store" element={
+          <Suspense fallback={<PageLoadingFallback />}>
+            <StorePage />
+          </Suspense>
+        } />
       )}
       {isSettingsEnabled && (
-        <Route path="/settings" element={<SettingsPage />} />
+        <Route path="/settings" element={
+          <Suspense fallback={<PageLoadingFallback />}>
+            <SettingsPage />
+          </Suspense>
+        } />
       )}
       {isAdminEnabled && (
         <>
@@ -384,7 +432,11 @@ export const AppRoutes: React.FC = () => {
         </>
       )}
       {/* New URL pattern: /{city-shortcode}/{cafe-slug} */}
-      <Route path="/:cityShortcode/:slug" element={<CafeDetailWrapper />} />
+      <Route path="/:cityShortcode/:slug" element={
+        <Suspense fallback={<PageLoadingFallback />}>
+          <CafeDetailWrapper />
+        </Suspense>
+      } />
 
       {/* Legacy route for backwards compatibility - redirect to new format */}
       <Route path="/cafe/:id" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/__tests__/AppRoutes.test.tsx
+++ b/frontend/src/components/__tests__/AppRoutes.test.tsx
@@ -154,37 +154,43 @@ describe('AppRoutes', () => {
     mockAuthStore.user = null
   })
 
-  it('should render map view on root path', () => {
+  it('should render map view on root path', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
         <AppRoutes />
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Map View')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Map View')).toBeInTheDocument()
+    })
   })
 
-  it('should render list view on /list path', () => {
+  it('should render list view on /list path', async () => {
     render(
       <MemoryRouter initialEntries={['/list']}>
         <AppRoutes />
       </MemoryRouter>
     )
 
-    expect(screen.getByText('List View')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('List View')).toBeInTheDocument()
+    })
   })
 
-  it('should render detail view on cafe paths', () => {
+  it('should render detail view on cafe paths', async () => {
     render(
       <MemoryRouter initialEntries={['/toronto/test-cafe']}>
         <AppRoutes />
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Detail View')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Detail View')).toBeInTheDocument()
+    })
   })
 
-  it('should redirect to map view when feed is disabled and /feed is accessed', () => {
+  it('should redirect to map view when feed is disabled and /feed is accessed', async () => {
     render(
       <MemoryRouter initialEntries={['/feed']}>
         <AppRoutes />
@@ -192,17 +198,21 @@ describe('AppRoutes', () => {
     )
 
     // Feed is disabled, should redirect to map view
-    expect(screen.getByText('Map View')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Map View')).toBeInTheDocument()
+    })
   })
 
-  it('should render passport view on /passport path', () => {
+  it('should render passport view on /passport path', async () => {
     render(
       <MemoryRouter initialEntries={['/passport']}>
         <AppRoutes />
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Passport View')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Passport View')).toBeInTheDocument()
+    })
   })
 
   it('should render events view on /events path', async () => {
@@ -218,49 +228,57 @@ describe('AppRoutes', () => {
     })
   })
 
-  it('should render about page on /about path', () => {
+  it('should render about page on /about path', async () => {
     render(
       <MemoryRouter initialEntries={['/about']}>
         <AppRoutes />
       </MemoryRouter>
     )
 
-    expect(screen.getByText('About Page')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('About Page')).toBeInTheDocument()
+    })
   })
 
-  it('should render contact page on /contact path', () => {
+  it('should render contact page on /contact path', async () => {
     render(
       <MemoryRouter initialEntries={['/contact']}>
         <AppRoutes />
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Contact Page')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Contact Page')).toBeInTheDocument()
+    })
   })
 
-  it('should render store page on /store path', () => {
+  it('should render store page on /store path', async () => {
     render(
       <MemoryRouter initialEntries={['/store']}>
         <AppRoutes />
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Store Page')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Store Page')).toBeInTheDocument()
+    })
   })
 
-  it('should render settings page on /settings path when authenticated', () => {
+  it('should render settings page on /settings path when authenticated', async () => {
     mockAuthStore.isAuthenticated = true
-    
+
     render(
       <MemoryRouter initialEntries={['/settings']}>
         <AppRoutes />
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Settings Page')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Settings Page')).toBeInTheDocument()
+    })
   })
 
-  it('should redirect to login when accessing protected routes without auth', () => {
+  it('should redirect to login when accessing protected routes without auth', async () => {
     render(
       <MemoryRouter initialEntries={['/settings']}>
         <AppRoutes />
@@ -269,10 +287,12 @@ describe('AppRoutes', () => {
 
     // Settings page doesn't require auth (ProtectedRoute is only for admin routes)
     // So it should be accessible
-    expect(screen.getByText('Settings Page')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Settings Page')).toBeInTheDocument()
+    })
   })
 
-  it('should handle 404 routes gracefully', () => {
+  it('should handle 404 routes gracefully', async () => {
     render(
       <MemoryRouter initialEntries={['/unknown-city/unknown-cafe']}>
         <AppRoutes />
@@ -280,30 +300,36 @@ describe('AppRoutes', () => {
     )
 
     // Unknown cafes should redirect to home
-    expect(screen.getByText('Map View')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Map View')).toBeInTheDocument()
+    })
   })
 
-  it('should handle dynamic cafe routes with slugs', () => {
+  it('should handle dynamic cafe routes with slugs', async () => {
     render(
       <MemoryRouter initialEntries={['/toronto/test-cafe']}>
         <AppRoutes />
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Detail View')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Detail View')).toBeInTheDocument()
+    })
   })
 
-  it('should handle route parameters correctly', () => {
+  it('should handle route parameters correctly', async () => {
     render(
       <MemoryRouter initialEntries={['/toronto/test-cafe']}>
         <AppRoutes />
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Detail View')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Detail View')).toBeInTheDocument()
+    })
   })
 
-  it('should handle nested admin routes', () => {
+  it('should handle nested admin routes', async () => {
     mockAuthStore.isAuthenticated = true
     mockAuthStore.user = { role: 'admin' }
 
@@ -316,11 +342,13 @@ describe('AppRoutes', () => {
     // Admin routes are lazy loaded and wrapped in ProtectedRoute which we mocked to render children
     // Since admin components are mocked, we won't see actual admin content in tests
     // Just verify no error is thrown
-    const body = document.body
-    expect(body).toBeInTheDocument()
+    await waitFor(() => {
+      const body = document.body
+      expect(body).toBeInTheDocument()
+    })
   })
 
-  it('should lazy load routes for performance', () => {
+  it('should lazy load routes for performance', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
         <AppRoutes />
@@ -328,6 +356,8 @@ describe('AppRoutes', () => {
     )
 
     // Routes should be lazy loaded (this is more of an implementation detail)
-    expect(screen.getByText('Map View')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Map View')).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
## Summary

Implements automatic code splitting via React.lazy() for all route components, reducing initial bundle size by **32%** (112KB → 76KB gzipped).

## Changes

### Route Component Lazy Loading
- ✅ Convert all route components to `React.lazy()`
  - Main views: MapView, ListView, DetailView
  - Feature pages: EventsView, PassportView, EventDetailView
  - Auth pages: LoginPage, UserProfilePage
  - Static pages: ContactPage, AboutPage, StorePage, SettingsPage
  - Admin pages: Already lazy-loaded (no changes needed)

### Suspense Boundaries
- ✅ Add `PageLoadingFallback` component (minimal spinner)
- ✅ Wrap all lazy routes with `<Suspense>` boundaries
- ✅ Maintain existing `AdminLoadingFallback` for admin routes

### Test Updates
- ✅ Update AppRoutes tests to use `waitFor()` for lazy-loaded components
- ✅ All tests passing (966/966)
- ✅ TypeScript checks passing

## Results

**Bundle Size Reduction:**
```
Before: index-D13xjyIj.js = 112.14 KB gzipped
After:  index-CN3u_j9Y.js = 76.36 KB gzipped
Savings: 35.78 KB (32% reduction) ✅
```

**Separate Chunks (loaded on-demand):**
- MapView: 32.62 KB
- DetailView: 51.50 KB
- ListView: 24.12 KB
- LoginPage: 6.51 KB
- EventsView: 8.13 KB
- etc.

## Benefits

1. **Meets bundle budget** - Initial load now 76KB (under 100KB target)
2. **Better mobile performance** - Users only download what they use
3. **Zero maintenance** - Vite handles code splitting automatically
4. **No icon barrel file needed** - lucide-react tree-shakes natively

## Alternative Considered

Initially explored creating a manual icon barrel file, but discovered:
- ❌ Tedious maintenance (manual export list)
- ❌ No actual benefit (lucide-react already tree-shakes)
- ✅ This approach is simpler and more effective

## Testing

```bash
npm test           # 966/966 passing ✅
npm run typecheck  # No errors ✅
npm run build      # Bundle size verified ✅
```

## Related

Closes #277