### PR TITLE
fix(tests): resolve PR 293 test failures

### DIFF
--- a/frontend/src/components/__tests__/DetailView.test.tsx
+++ b/frontend/src/components/__tests__/DetailView.test.tsx
@@ -34,6 +34,47 @@ vi.mock('../../constants/copy', () => ({
       title: 'Events',
       viewDetails: 'View Details',
     },
+    checkin: {
+      checkIn: 'Check In',
+      checkedIn: 'Checked In',
+      checkingIn: 'Checking in...',
+      title: 'Check in to',
+      subtitle: 'Share your experience at this cafe',
+      notesLabel: 'Notes (Optional)',
+      notesPlaceholder: 'How was your visit? Any recommendations?',
+      photosLabel: 'Photos (Optional)',
+      ratingLabel: 'Quick Rating',
+      ratingOptional: '(Optional)',
+      submitButton: 'Check In',
+      submittingButton: 'Checking in...',
+      cancel: 'Cancel',
+      successTitle: 'Checked in successfully!',
+      successMessage: 'Your check-in has been recorded.',
+      successClose: 'Close',
+      errorTitle: 'Check-in Failed',
+      errorMessage: 'Unable to record your check-in. Please try again.',
+      errorRetry: 'Try Again',
+      errorClose: 'Close',
+      addPhotos: 'Add Photos',
+      removePhoto: 'Remove photo',
+      photoUploading: 'Uploading photo...',
+      photoError: 'Failed to upload photo',
+      ratingPrompt: 'Rate your experience',
+      stars: (count: number) => `${count} star${count !== 1 ? 's' : ''}`,
+      clearRating: 'Clear rating',
+      notesMaxLength: 500,
+      notesCharCount: (current: number, max: number) => `${current}/${max}`,
+      notesTooLong: (max: number) => `Notes must be ${max} characters or less`,
+      alreadyCheckedIn: 'You\'ve already checked in to this cafe today',
+      networkError: 'Check your internet connection and try again',
+    },
+    photos: {
+      upload: {
+        invalidFileType: 'Invalid file type. Please upload a JPEG, PNG, or WebP image.',
+        fileTooLarge: 'File too large. Maximum size is 5MB.',
+        emptyFile: 'File is empty. Please select a valid image.',
+      },
+    },
   },
 }))
 
@@ -67,11 +108,27 @@ vi.mock('../reviews/ReviewForm', () => ({
   ),
 }))
 
+// Mock checkin components
+vi.mock('../checkin', () => ({
+  CheckInButton: ({ cafe, isCheckedIn, onCheckInSuccess }: any) => (
+    <div data-testid="check-in-button">
+      <button onClick={onCheckInSuccess}>Check In</button>
+    </div>
+  ),
+}))
+
 // Mock hooks
 vi.mock('../../hooks/useAppFeatures', () => ({
   useAppFeatures: () => ({
     isPassportEnabled: true,
     isUserAccountsEnabled: true,
+  }),
+}))
+
+vi.mock('../../hooks/useUserFeatures', () => ({
+  useUserFeatures: () => ({
+    isUserSocialEnabled: true,
+    hasUserSocial: true,
   }),
 }))
 

--- a/frontend/src/components/checkin/__tests__/CheckInButton.test.tsx
+++ b/frontend/src/components/checkin/__tests__/CheckInButton.test.tsx
@@ -27,10 +27,14 @@ vi.mock('../CheckInModal', () => ({
 }))
 
 // Mock user features hook
-vi.mock('../../../hooks/useUserFeatures', () => ({
-  useUserFeatures: vi.fn(() => ({
+const { mockUseUserFeatures } = vi.hoisted(() => ({
+  mockUseUserFeatures: vi.fn(() => ({
     hasUserSocial: true,
   })),
+}))
+
+vi.mock('../../../hooks/useUserFeatures', () => ({
+  useUserFeatures: mockUseUserFeatures,
 }))
 
 // Mock UI components
@@ -84,6 +88,8 @@ describe('CheckInButton', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset useUserFeatures mock to default
+    mockUseUserFeatures.mockReturnValue({ hasUserSocial: true })
   })
 
   it('renders check-in button when not checked in', () => {
@@ -144,8 +150,7 @@ describe('CheckInButton', () => {
   })
 
   it('does not render when user social features are disabled', () => {
-    const { useUserFeatures } = require('../../../hooks/useUserFeatures')
-    useUserFeatures.mockReturnValue({ hasUserSocial: false })
+    mockUseUserFeatures.mockReturnValue({ hasUserSocial: false })
 
     const { container } = render(
       <CheckInButton


### PR DESCRIPTION
Fixes two critical test failures in PR 293 (check-in feature):

1. DetailView.test.tsx: Added missing COPY.checkin and COPY.photos.upload mock sections
   - CheckInModal was accessing COPY.checkin.notesMaxLength at module level
   - Mock was incomplete, causing undefined reference errors
   - Added all required checkin and photos copy constants to the mock

2. CheckInButton.test.tsx: Fixed useUserFeatures mock hoisting issue
   - Used vi.hoisted() to properly declare mockUseUserFeatures before vi.mock()
   - Removed dynamic require() that was causing module not found error
   - Mock is now accessible throughout the test file

All 23 tests now passing (5 CheckInButton + 18 DetailView).