### PR TITLE
perf(admin): optimize tooltip positioning with useMemo

### DIFF
--- a/frontend/src/components/admin/CafeManagementPage.tsx
+++ b/frontend/src/components/admin/CafeManagementPage.tsx
@@ -68,6 +68,9 @@ export const CafeManagementPage: React.FC = () => {
     const missingFields = getMissingFields(cafe)
     const isTooltipOpen = openTooltip === cafe.id
     
+    // Memoize the parseInt call for tooltip positioning threshold
+    const threshold = useMemo(() => parseInt(spacing.tooltipPositionThreshold, 10), [])
+    
     if (missingFields.length === 0) {
       return null
     }
@@ -81,7 +84,6 @@ export const CafeManagementPage: React.FC = () => {
       const spaceBelow = window.innerHeight - rect.bottom
       
       // If not enough space above (< threshold for tooltip), position below
-      const threshold = parseInt(spacing.tooltipPositionThreshold, 10)
       return spaceAbove < threshold && spaceBelow > threshold ? 'top-full mt-2' : 'bottom-full mb-2'
     }
 


### PR DESCRIPTION
Memoize parseInt(spacing.tooltipPositionThreshold, 10) call in CafeManagementPage.tsx to avoid recalculating on every tooltip position calculation.

Fixes #303

Generated with [Claude Code](https://claude.ai/code)