### PR TITLE
fix(design-tokens): standardize tooltip spacing units to rem

### DIFF
--- a/frontend/src/styles/spacing.ts
+++ b/frontend/src/styles/spacing.ts
@@ -37,8 +37,8 @@ export const spacing = {
   tooltipPadding: '0.75rem',  // 12px - Vertical padding (py-3)
   tooltipPaddingX: '1rem',    // 16px - Horizontal padding (px-4)
   tooltipOffset: '0.25rem',   // 4px - Distance from trigger element
-  tooltipMaxWidth: '480px',   // Maximum width for large tooltips
-  tooltipMinWidth: '280px',   // Minimum width for content
+  tooltipMaxWidth: '30rem',   // Maximum width for large tooltips (480px)
+  tooltipMinWidth: '17.5rem', // Minimum width for content (280px)
   tooltipArrowSize: '4px',    // Border width for tooltip arrows
   tooltipPositionThreshold: '120px', // Space needed above for upward positioning
 } as const


### PR DESCRIPTION
Standardizes tooltip spacing units to use rem instead of px for consistency with other design tokens.

## Changes
- Convert `tooltipMaxWidth` from '480px' to '30rem'
- Convert `tooltipMinWidth` from '280px' to '17.5rem'

## Benefits
- Consistent rem-based scaling with other design tokens
- Maintains identical visual appearance
- Preserves responsive behavior across viewport sizes

Closes #301

Generated with [Claude Code](https://claude.ai/code)