### PR TITLE
refactor(design-tokens): extract hardcoded tooltip trigger dimensions

### DIFF
--- a/frontend/src/components/admin/CafeManagementPage.tsx
+++ b/frontend/src/components/admin/CafeManagementPage.tsx
@@ -102,8 +102,8 @@ export const CafeManagementPage: React.FC = () => {
         <span
           className="inline-flex items-center justify-center bg-amber-100 text-amber-600 border border-amber-300 cursor-help hover:bg-amber-200 transition-colors"
           style={{
-            width: '20px',
-            height: '20px',
+            width: spacing.tooltipTriggerSize,
+            height: spacing.tooltipTriggerSize,
             borderRadius: borderRadius.full
           }}
           title={COPY.admin.cafeManagement.missingFieldsList(missingFields)}

--- a/frontend/src/styles/spacing.ts
+++ b/frontend/src/styles/spacing.ts
@@ -41,6 +41,7 @@ export const spacing = {
   tooltipMinWidth: '280px',   // Minimum width for content
   tooltipArrowSize: '4px',    // Border width for tooltip arrows
   tooltipPositionThreshold: '120px', // Space needed above for upward positioning
+  tooltipTriggerSize: '20px', // Size for small tooltip trigger buttons
 } as const
 
 /**


### PR DESCRIPTION
Fixes #304

Extracts hardcoded 20px width/height values from tooltip trigger button in CafeManagementPage.tsx to a centralized design token.

## Changes
- Add `spacing.tooltipTriggerSize: '20px'` design token in spacing.ts
- Replace hardcoded dimensions in CafeManagementPage.tsx with design token
- Maintains existing 20px dimensions and visual appearance
- Follows established design system patterns

## Accessibility Consideration
The 20px size is intentionally smaller than the WCAG 44px touch target as this is a visual indicator element, not a primary interactive button.

Generated with [Claude Code](https://claude.ai/code)