### PR TITLE
feat(theme): change default theme from 'system' to 'light'

### DIFF
--- a/frontend/src/stores/themeStore.ts
+++ b/frontend/src/stores/themeStore.ts
@@ -38,7 +38,7 @@ const resolveTheme = (theme: Theme): 'light' | 'dark' => {
 export const useThemeStore = create<ThemeState>()(
   persist(
     (set, get) => ({
-      theme: 'system', // Default to system preference
+      theme: 'light', // Default to light mode
       resolvedTheme: 'light', // Will be updated on initialization
       
       setTheme: (theme: Theme) => {


### PR DESCRIPTION
This PR implements the theme default change requested in issue #313.

## Changes
- Updated default theme from 'system' to 'light' in `themeStore.ts`
- First-time users now see light theme regardless of OS preference
- Existing users keep their saved preferences (backward compatible)
- All existing theme toggle functionality preserved

## Testing
- [ ] Clear localStorage to simulate new user
- [ ] Verify light theme shows by default
- [ ] Test theme toggle cycles correctly
- [ ] Verify persistence after page refresh

Closes #313

Generated with [Claude Code](https://claude.ai/code)